### PR TITLE
feat: 챔피언 분석 상세 페이지 SSR 전환

### DIFF
--- a/src/app/champion-stats/[championId]/not-found.tsx
+++ b/src/app/champion-stats/[championId]/not-found.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Header, Navigation, Footer } from "@/widgets/layout";
+import { useParams } from "next/navigation";
+
+export default function ChampionNotFoundPage() {
+  const params = useParams();
+  const championId = (params?.championId as string) ?? "";
+
+  return (
+    <div className="min-h-screen bg-surface">
+      <Header />
+      <Navigation />
+      <main className="max-w-5xl mx-auto py-8">
+        <div className="text-center py-20">
+          <p className="text-lg text-on-surface-medium">
+            챔피언을 찾을 수 없습니다:{" "}
+            <span className="font-medium text-on-surface">{championId}</span>
+          </p>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/champion-stats/[championId]/page.tsx
+++ b/src/app/champion-stats/[championId]/page.tsx
@@ -1,4 +1,10 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { serverApiClient } from "@/shared/api/server-client";
+import { getChampionStats, getChampionImageUrl } from "@/entities/champion";
+import { getChampionKeyFromId } from "@/entities/champion/lib/serverChampionData";
+import { getSeasons } from "@/entities/season";
+import { logger } from "@/shared/lib/logger";
 import { ChampionStatsDetailPageClient } from "@/views/champion-stats";
 
 interface PageProps {
@@ -6,23 +12,102 @@ interface PageProps {
   searchParams: Promise<{ tier?: string; patch?: string; platformId?: string }>;
 }
 
+async function resolveLatestPatch(): Promise<string | null> {
+  try {
+    const seasons = await getSeasons(serverApiClient);
+    if (seasons.length === 0) return null;
+    const latestSeason = seasons.reduce((latest, s) =>
+      s.seasonValue > latest.seasonValue ? s : latest
+    );
+    return latestSeason.patchVersions[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { championId } = await params;
+  const championInfo = await getChampionKeyFromId(championId);
+  const championName = championInfo?.name ?? championId;
+  const imageUrl = getChampionImageUrl(championId);
+
+  const title = `${championName} 챔피언 통계 - METAPICK`;
+  const description = `${championName}의 승률, 아이템 빌드, 룬, 스킬 트리, 상성 통계를 확인하세요.`;
+
   return {
-    title: `${championId} 챔피언 통계 - METAPICK`,
-    description: `${championId}의 승률, 아이템 빌드, 룬, 스킬 트리, 상성 통계를 확인하세요.`,
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      ...(imageUrl && { images: [{ url: imageUrl }] }),
+      type: "website",
+      siteName: "METAPICK",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
+      ...(imageUrl && { images: [imageUrl] }),
+    },
   };
 }
 
 export default async function ChampionStatsDetailPage({ params, searchParams }: PageProps) {
   const { championId } = await params;
   const { tier, patch, platformId } = await searchParams;
+
+  const championInfo = await getChampionKeyFromId(championId);
+  if (!championInfo) {
+    notFound();
+  }
+
+  const { key: championKey } = championInfo;
+  const region = platformId || "kr";
+  const selectedTier = tier || "CHALLENGER";
+
+  let activePatch = patch || "";
+  if (!activePatch) {
+    const latestPatch = await resolveLatestPatch();
+    if (!latestPatch) {
+      return (
+        <ChampionStatsDetailPageClient
+          championId={championId}
+          championKey={championKey}
+          initialTier={tier}
+          initialPatch={patch}
+          initialPlatformId={platformId}
+        />
+      );
+    }
+    activePatch = latestPatch;
+  }
+
+  let initialStatsData = null;
+  try {
+    initialStatsData = await getChampionStats(
+      region,
+      championKey,
+      activePatch,
+      selectedTier,
+      serverApiClient
+    );
+  } catch (error) {
+    logger.error("Failed to load champion stats server-side", {
+      url: `/champion-stats/${championId}`,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+
   return (
     <ChampionStatsDetailPageClient
       championId={championId}
+      championKey={championKey}
       initialTier={tier}
       initialPatch={patch}
       initialPlatformId={platformId}
+      initialActivePatch={activePatch}
+      initialStatsData={initialStatsData}
     />
   );
 }

--- a/src/entities/champion/api/championStatsApi.ts
+++ b/src/entities/champion/api/championStatsApi.ts
@@ -1,3 +1,4 @@
+import type { AxiosInstance } from "axios";
 import { apiClient } from "@/shared/api/client";
 import type { ApiResponse } from "@/shared/api/types";
 import type { ChampionStatsResponse } from "../types";
@@ -6,9 +7,10 @@ export async function getChampionStats(
   region: string,
   championId: string,
   patch: string,
-  tier?: string
+  tier?: string,
+  client: AxiosInstance = apiClient
 ): Promise<ChampionStatsResponse> {
-  const response = await apiClient.get<ApiResponse<ChampionStatsResponse>>(
+  const response = await client.get<ApiResponse<ChampionStatsResponse>>(
     `/v1/${region}/champion-stats`,
     { params: { championId, patch, ...(tier && { tier }) } }
   );

--- a/src/entities/champion/lib/serverChampionData.ts
+++ b/src/entities/champion/lib/serverChampionData.ts
@@ -1,0 +1,25 @@
+import fs from "fs/promises";
+import path from "path";
+import type { ChampionJson } from "@/shared/model/game-data";
+
+let cachedPromise: Promise<ChampionJson> | null = null;
+
+export function loadChampionDataServer(): Promise<ChampionJson> {
+  if (!cachedPromise) {
+    cachedPromise = (async () => {
+      const filePath = path.join(process.cwd(), "public", "data", "championFull.json");
+      const raw = await fs.readFile(filePath, "utf-8");
+      return JSON.parse(raw) as ChampionJson;
+    })();
+  }
+  return cachedPromise;
+}
+
+export async function getChampionKeyFromId(
+  championId: string
+): Promise<{ key: string; name: string } | null> {
+  const data = await loadChampionDataServer();
+  const champ = data.data[championId];
+  if (!champ) return null;
+  return { key: champ.key, name: champ.name };
+}

--- a/src/entities/champion/model/useChampionStats.ts
+++ b/src/entities/champion/model/useChampionStats.ts
@@ -6,12 +6,14 @@ export function useChampionStats(
   championKey: string,
   patch: string,
   tier?: string,
-  region: string = "kr"
+  region: string = "kr",
+  options?: { initialData?: ChampionStatsResponse }
 ) {
   return useQuery<ChampionStatsResponse, Error>({
     queryKey: ["champion-stats", championKey, patch, tier, region],
     queryFn: () => getChampionStats(region, championKey, patch, tier),
     enabled: !!championKey && !!patch,
     staleTime: 5 * 60 * 1000,
+    initialData: options?.initialData,
   });
 }

--- a/src/entities/season/api/seasonApi.ts
+++ b/src/entities/season/api/seasonApi.ts
@@ -1,14 +1,20 @@
+import type { AxiosInstance } from "axios";
 import { apiClient } from "@/shared/api/client";
 import type { ApiResponse } from "@/shared/api/types";
 import type { Season } from "../types";
 
-export async function getSeasons(): Promise<Season[]> {
-  const response = await apiClient.get<ApiResponse<Season[]>>("/v1/seasons");
+export async function getSeasons(
+  client: AxiosInstance = apiClient
+): Promise<Season[]> {
+  const response = await client.get<ApiResponse<Season[]>>("/v1/seasons");
   return response.data.data;
 }
 
-export async function getSeasonById(seasonId: number): Promise<Season> {
-  const response = await apiClient.get<ApiResponse<Season>>(
+export async function getSeasonById(
+  seasonId: number,
+  client: AxiosInstance = apiClient
+): Promise<Season> {
+  const response = await client.get<ApiResponse<Season>>(
     `/v1/seasons/${seasonId}`
   );
   return response.data.data;

--- a/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
+++ b/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
@@ -12,24 +12,30 @@ import { Header, Navigation, Footer } from "@/widgets/layout";
 import {
   useChampionStats,
   type ApiPositionType,
+  type ChampionStatsResponse,
 } from "@/entities/champion";
-import { useGameDataStore } from "@/shared/model/game-data";
 import { useSeasonStore } from "@/entities/season";
 import { ChampionStatsFilters } from "@/features/champion-stats-filter";
 import { useMemo, useState } from "react";
 
 interface ChampionStatsDetailPageClientProps {
   championId: string;
+  championKey: string;
   initialTier?: string;
   initialPatch?: string;
   initialPlatformId?: string;
+  initialActivePatch?: string;
+  initialStatsData?: ChampionStatsResponse | null;
 }
 
 export default function ChampionStatsDetailPageClient({
   championId,
+  championKey,
   initialTier,
   initialPatch,
   initialPlatformId,
+  initialActivePatch,
+  initialStatsData,
 }: ChampionStatsDetailPageClientProps) {
   const [selectedPosition, setSelectedPosition] = useState<ApiPositionType | null>(null);
   const [selectedTier, setSelectedTier] = useState(initialTier || "CHALLENGER");
@@ -37,24 +43,24 @@ export default function ChampionStatsDetailPageClient({
   const [selectedPlatform, setSelectedPlatform] = useState(initialPlatformId || "kr");
 
   const latestSeason = useSeasonStore((s) => s.getLatestSeason());
-  const championData = useGameDataStore((s) => s.championData);
   const latestPatches = latestSeason?.patchVersions ?? [];
-  const activePatch = selectedPatch || latestPatches[0] || "";
+  const activePatch = selectedPatch || latestPatches[0] || initialActivePatch || "";
 
-  // 영문명 → numeric key 변환
-  const championKey = useMemo(() => {
-    if (!championData?.data) return "";
-    const champ = championData.data[championId];
-    return champ?.key || "";
-  }, [championData, championId]);
-
-  const isInvalidChampion = !!championData?.data && !championKey;
+  const isInitialRequest = useMemo(() => {
+    if (!initialStatsData || !initialActivePatch) return false;
+    return (
+      activePatch === initialActivePatch &&
+      selectedTier === (initialTier || "CHALLENGER") &&
+      selectedPlatform === (initialPlatformId || "kr")
+    );
+  }, [activePatch, selectedTier, selectedPlatform, initialActivePatch, initialTier, initialPlatformId, initialStatsData]);
 
   const { data, isLoading, isError } = useChampionStats(
     championKey,
     activePatch,
     selectedTier,
-    selectedPlatform
+    selectedPlatform,
+    isInitialRequest ? { initialData: initialStatsData! } : undefined
   );
 
   // 사용 가능한 포지션 목록 추출
@@ -82,72 +88,53 @@ export default function ChampionStatsDetailPageClient({
       <Header />
       <Navigation />
       <main className="max-w-5xl mx-auto py-8">
-        {isInvalidChampion ? (
-          <div className="text-center py-20">
-            <p className="text-lg text-on-surface-medium">
-              챔피언을 찾을 수 없습니다: <span className="font-medium text-on-surface">{championId}</span>
-            </p>
-          </div>
-        ) : (
-          <>
-            {/* <div className="mb-6">
-          <h1 className="text-3xl font-bold text-on-surface mb-2">
-            {championName} 통계
-          </h1>
-          <p className="text-on-surface-medium">
-            승률, 아이템, 룬, 스킬, 상성 통계를 확인하세요
-          </p>
-        </div> */}
+        <div className="space-y-6">
+          <ChampionStatsFilters
+            selectedTier={selectedTier}
+            onTierChange={setSelectedTier}
+            selectedPatch={selectedPatch}
+            onPatchChange={setSelectedPatch}
+            selectedPlatform={selectedPlatform}
+            onPlatformChange={setSelectedPlatform}
+          />
 
-            <div className="space-y-6">
-              <ChampionStatsFilters
-                selectedTier={selectedTier}
-                onTierChange={setSelectedTier}
-                selectedPatch={selectedPatch}
-                onPatchChange={setSelectedPatch}
-                selectedPlatform={selectedPlatform}
-                onPlatformChange={setSelectedPlatform}
-              />
+          <PositionTabs
+            selectedPosition={effectivePosition ?? "TOP"}
+            onSelectPosition={setSelectedPosition}
+            availablePositions={availablePositions.length > 0 ? availablePositions : undefined}
+          />
 
-              <PositionTabs
-                selectedPosition={effectivePosition ?? "TOP"}
-                onSelectPosition={setSelectedPosition}
-                availablePositions={availablePositions.length > 0 ? availablePositions : undefined}
-              />
-
-              {isLoading ? (
-                <div className="flex items-center justify-center py-20">
-                  <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-                </div>
-              ) : isError ? (
-                <div className="text-center py-20 text-loss">
-                  통계 데이터를 불러오는 중 오류가 발생했습니다.
-                </div>
-              ) : currentPositionStats ? (
-                <>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <ChampionOverview
-                      data={currentPositionStats}
-                      tier={data!.tier}
-                      championId={championId}
-                    />
-                    <SkillTreeStats
-                      data={currentPositionStats.skillBuilds.slice(0, 1)}
-                      championName={championId}
-                    />
-                  </div>
-                  <ItemBuildStats data={currentPositionStats.itemBuilds} startItemBuilds={currentPositionStats.startItemBuilds} />
-                  <RuneStats data={currentPositionStats.runeBuilds} />
-                  <MatchupStats data={currentPositionStats.matchups ?? []} />
-                </>
-              ) : activePatch ? (
-                <div className="text-center py-20 text-on-surface-medium">
-                  해당 패치의 통계 데이터가 없습니다.
-                </div>
-              ) : null}
+          {isLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
             </div>
-          </>
-        )}
+          ) : isError ? (
+            <div className="text-center py-20 text-loss">
+              통계 데이터를 불러오는 중 오류가 발생했습니다.
+            </div>
+          ) : currentPositionStats ? (
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <ChampionOverview
+                  data={currentPositionStats}
+                  tier={data!.tier}
+                  championId={championId}
+                />
+                <SkillTreeStats
+                  data={currentPositionStats.skillBuilds.slice(0, 1)}
+                  championName={championId}
+                />
+              </div>
+              <ItemBuildStats data={currentPositionStats.itemBuilds} startItemBuilds={currentPositionStats.startItemBuilds} />
+              <RuneStats data={currentPositionStats.runeBuilds} />
+              <MatchupStats data={currentPositionStats.matchups ?? []} />
+            </>
+          ) : activePatch ? (
+            <div className="text-center py-20 text-on-surface-medium">
+              해당 패치의 통계 데이터가 없습니다.
+            </div>
+          ) : null}
+        </div>
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- 챔피언 분석 상세 페이지(`/champion-stats/[championId]`) CSR → SSR 전환
- 서버에서 챔피언 통계 데이터 프리페칭으로 초기 로딩 속도 개선
- 한글 챔피언명, OG 이미지, Twitter Card 메타데이터 추가 (SEO 강화)
- API 실패 시 기존 CSR 동작으로 graceful degradation
- 잘못된 championId 접근 시 커스텀 404 페이지 제공

## Changed Files
- `src/app/champion-stats/[championId]/page.tsx` — SSR 데이터 페칭 로직 추가
- `src/app/champion-stats/[championId]/not-found.tsx` — 커스텀 404 페이지 (신규)
- `src/entities/champion/lib/serverChampionData.ts` — 서버 전용 챔피언 데이터 유틸 (신규)
- `src/entities/champion/api/championStatsApi.ts` — `client` 파라미터 추가
- `src/entities/season/api/seasonApi.ts` — `client` 파라미터 추가
- `src/entities/champion/model/useChampionStats.ts` — `initialData` 옵션 추가
- `src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx` — 서버 초기 데이터 수용