### PR TITLE
feat: 골드 타임라인 실데이터 연동, 룬 파싱 버그 수정, 이미지 호스트 변경

### DIFF
--- a/src/entities/match/types.ts
+++ b/src/entities/match/types.ts
@@ -126,6 +126,8 @@ export interface TeamInfo {
   inhibitorKills: number;
   championId: number[];
   pickTurn: number[];
+  goldTimeline?: number[];
+  timestamps?: number[];
 }
 
 export interface ChampionStat {

--- a/src/shared/config/image.ts
+++ b/src/shared/config/image.ts
@@ -1,1 +1,1 @@
-export const IMAGE_HOST = process.env.NEXT_PUBLIC_IMAGE_HOST || 'https://static.mmrtr.shop';
+export const IMAGE_HOST = process.env.NEXT_PUBLIC_IMAGE_HOST || 'https://static.metapick.me';

--- a/src/shared/lib/rune.ts
+++ b/src/shared/lib/rune.ts
@@ -43,7 +43,7 @@ export function normalizeRunes(runeStyle: RuneStyle | null): NormalizedRunes | n
   }
 
   // Format B: flat 구조 (primaryRuneId + primaryRuneIds)
-  if (runeStyle.primaryRuneId && runeStyle.primaryRuneIds) {
+  if (runeStyle.primaryRuneId !== undefined && runeStyle.primaryRuneIds) {
     return {
       primaryTreeId: runeStyle.primaryRuneId,
       secondaryTreeId: runeStyle.secondaryRuneId ?? 0,
@@ -53,7 +53,7 @@ export function normalizeRunes(runeStyle: RuneStyle | null): NormalizedRunes | n
   }
 
   // Format C: flat 구조 (primaryStyleId + primaryPerk0~3)
-  if (runeStyle.primaryStyleId && runeStyle.primaryPerk0 !== undefined) {
+  if (runeStyle.primaryStyleId !== undefined && runeStyle.primaryPerk0 !== undefined) {
     return {
       primaryTreeId: runeStyle.primaryStyleId,
       secondaryTreeId: runeStyle.subStyleId ?? 0,

--- a/src/widgets/ingame/ui/IngamePlayer.tsx
+++ b/src/widgets/ingame/ui/IngamePlayer.tsx
@@ -46,7 +46,7 @@ export default function IngamePlayer({
 
   const championImageUrl = champId
     ? getChampionImageUrl(champId)
-    : `https://static.mmrtr.shop/champion/${participant.championId}.png`;
+    : `https://static.metapick.me/champion/${participant.championId}.png`;
 
   const perks = participant.perks;
   const mainPerkId = perks?.perkIds?.[0];

--- a/src/widgets/match-detail/ui/GoldFlowChart.tsx
+++ b/src/widgets/match-detail/ui/GoldFlowChart.tsx
@@ -21,34 +21,20 @@ ChartJS.register(
   Tooltip
 );
 
-interface GoldFlowEntry {
-  teamId: number;
-  timestamp: number;
-  total_gold: number;
+interface GoldFlowChartProps {
+  blueGoldTimeline: number[];
+  redGoldTimeline: number[];
+  timestamps: number[];
 }
 
-// 더미 데이터: 1분 간격, 30분 게임
-const DUMMY_DATA: GoldFlowEntry[] = (() => {
-  const entries: GoldFlowEntry[] = [];
-  let blueGold = 500;
-  let redGold = 500;
-
-  for (let t = 0; t <= 30; t++) {
-    blueGold += Math.floor(Math.random() * 800 + 400);
-    redGold += Math.floor(Math.random() * 800 + 400);
-    entries.push({ teamId: 100, timestamp: t, total_gold: blueGold });
-    entries.push({ teamId: 200, timestamp: t, total_gold: redGold });
-  }
-  return entries;
-})();
-
-export default function GoldFlowChart() {
-  const blueData = DUMMY_DATA.filter((d) => d.teamId === 100);
-  const redData = DUMMY_DATA.filter((d) => d.teamId === 200);
-
-  const labels = blueData.map((d) => `${d.timestamp}m`);
-  const goldDiffs = blueData.map(
-    (b, i) => b.total_gold - redData[i].total_gold
+export default function GoldFlowChart({
+  blueGoldTimeline,
+  redGoldTimeline,
+  timestamps,
+}: GoldFlowChartProps) {
+  const labels = timestamps.map((ts) => `${Math.floor(ts / 60000)}m`);
+  const goldDiffs = blueGoldTimeline.map(
+    (blue, i) => blue - (redGoldTimeline[i] ?? 0)
   );
 
   const maxAbsDiff = Math.max(...goldDiffs.map(Math.abs), 1000);

--- a/src/widgets/match-detail/ui/MatchDetailOverview.tsx
+++ b/src/widgets/match-detail/ui/MatchDetailOverview.tsx
@@ -413,7 +413,15 @@ export default function MatchDetailOverview({
     <>
       <div className="space-y-4">
         {renderTeam(blueTeam, "blue", blueTeamStats)}
-        <GoldFlowChart />
+        {detail.teamInfoData.blueTeam.goldTimeline &&
+          detail.teamInfoData.redTeam.goldTimeline &&
+          detail.teamInfoData.blueTeam.timestamps && (
+          <GoldFlowChart
+            blueGoldTimeline={detail.teamInfoData.blueTeam.goldTimeline}
+            redGoldTimeline={detail.teamInfoData.redTeam.goldTimeline}
+            timestamps={detail.teamInfoData.blueTeam.timestamps}
+          />
+        )}
         {renderTeam(redTeam, "red", redTeamStats)}
       </div>
     </>

--- a/src/widgets/match-detail/ui/SkillOrderGrid.tsx
+++ b/src/widgets/match-detail/ui/SkillOrderGrid.tsx
@@ -92,7 +92,7 @@ export default function SkillOrderGrid({ skillSeq, championName }: SkillOrderGri
   );
 }
 
-const IMAGE_HOST = process.env.NEXT_PUBLIC_IMAGE_HOST || 'https://static.mmrtr.shop';
+const IMAGE_HOST = process.env.NEXT_PUBLIC_IMAGE_HOST || 'https://static.metapick.me';
 
 function SkillLabel({ skillKey, skillIndex, championName }: { skillKey: string; skillIndex: number; championName?: string }) {
   const [imgError, setImgError] = useState(false);

--- a/src/widgets/match-history/ui/MatchSummary.tsx
+++ b/src/widgets/match-history/ui/MatchSummary.tsx
@@ -266,7 +266,7 @@ export default function MatchSummary({ matches, dailyCounts, isDailyCountLoading
             <div className="flex items-center justify-around mt-1">
               {positions.map((pos, index) => {
                 const positionUpper = pos.position?.toUpperCase() || "";
-                const positionImageUrl = `https://static.mmrtr.shop/position/Position-${positionUpper}.png`;
+                const positionImageUrl = `https://static.metapick.me/position/Position-${positionUpper}.png`;
                 return (
                   <div key={index} className="relative w-5 h-5 shrink-0">
                     <Image


### PR DESCRIPTION
## Summary
- GoldFlowChart 더미 데이터를 API `goldTimeline`/`timestamps` 실데이터로 교체
- `TeamInfo` 타입에 `goldTimeline`, `timestamps` 필드 추가
- `normalizeRunes` truthy 체크를 `!== undefined`로 수정하여 값이 0일 때 매칭 실패하는 버그 해결
- 이미지 호스트 `static.mmrtr.shop` → `static.metapick.me` 전환 (4곳)

## Test plan
- [ ] 소환사 전적 상세 페이지에서 골드 타임라인 차트가 실데이터로 표시되는지 확인
- [ ] 룬 아이콘이 정상 표시되는지 확인 (콘솔 경고 없음)
- [ ] 챔피언/포지션/스킬 이미지가 새 호스트에서 정상 로드되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)