### PR TITLE
fix: Next.js 이미지 도메인을 static.metapick.me로 변경

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "static.mmrtr.shop",
+        hostname: "static.metapick.me",
         pathname: "/**",
       },
     ],


### PR DESCRIPTION
## Summary
- `next.config.ts`의 `remotePatterns` 호스트를 `static.mmrtr.shop` → `static.metapick.me`로 변경
- 이미지 호스트 마이그레이션 후 Next.js 이미지 최적화(`/_next/image`) 요청 시 도메인 차단 에러 수정

## Test plan
- [ ] 챔피언/아이템/스펠 등 이미지가 정상 로드되는지 확인
- [ ] `/_next/image?url=https%3A%2F%2Fstatic.metapick.me%2F...` 요청이 정상 응답하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)