### PR TITLE
feat(champion-stats): bootBuilds 응답 처리 및 신발 빌드 섹션 추가

### DIFF
--- a/src/entities/champion/index.ts
+++ b/src/entities/champion/index.ts
@@ -9,7 +9,7 @@ export { WIN_RATE_COLOR_CLASSES, getWinRateTextClass, calcWinRateCeil2 } from ".
 export type {
   ChampionRotationResponse, PositionType, MatchupData,
   ItemBuildData, StartItemBuildData, BootBuildData, RuneBuildData, SkillBuildData,
-  SpellStatsData, ItemStatByOrder,
+  SpellStatsData,
   ChampionPositionStats, ChampionStatsResponse,
   ApiPositionType, PositionChampionEntry, PositionChampionStats,
 } from "./types";

--- a/src/entities/champion/index.ts
+++ b/src/entities/champion/index.ts
@@ -8,7 +8,7 @@ export { getChampionById, getChampionsByIds, getChampionImageUrl, getChampionNam
 export { WIN_RATE_COLOR_CLASSES, getWinRateTextClass, calcWinRateCeil2 } from "./lib/championStatsUtils";
 export type {
   ChampionRotationResponse, PositionType, MatchupData,
-  ItemBuildData, StartItemBuildData, RuneBuildData, SkillBuildData,
+  ItemBuildData, StartItemBuildData, BootBuildData, RuneBuildData, SkillBuildData,
   SpellStatsData, ItemStatByOrder,
   ChampionPositionStats, ChampionStatsResponse,
   ApiPositionType, PositionChampionEntry, PositionChampionStats,

--- a/src/entities/champion/types.ts
+++ b/src/entities/champion/types.ts
@@ -29,6 +29,13 @@ export interface StartItemBuildData {
   pickRate: number;
 }
 
+export interface BootBuildData {
+  bootId: number;
+  games: number;
+  winRate: number;
+  pickRate: number;
+}
+
 export interface RuneBuildData {
   primaryStyleId: number;
   subStyleId: number;
@@ -76,6 +83,7 @@ export interface ChampionPositionStats {
   matchups: MatchupData[];
   itemBuilds: ItemBuildData[];
   startItemBuilds: StartItemBuildData[];
+  bootBuilds: BootBuildData[];
   runeBuilds: RuneBuildData[];
   skillBuilds: SkillBuildData[];
   spellStats: SpellStatsData[];

--- a/src/entities/champion/types.ts
+++ b/src/entities/champion/types.ts
@@ -51,7 +51,7 @@ export interface RuneBuildData {
 }
 
 export interface SkillBuildData {
-  skillBuild: string; // "Q,E,W,Q,Q,R,Q,E,Q,E,R,E,E,W,W"
+  skillBuild: string; // BQ: "[1,2,1,2,2,3,...]" / 레거시: "Q,E,W,Q,Q,R,..."
   games: number;
   winRate: number;
   pickRate: number;
@@ -60,14 +60,6 @@ export interface SkillBuildData {
 export interface SpellStatsData {
   summoner1Id: number;
   summoner2Id: number;
-  games: number;
-  winRate: number;
-  pickRate: number;
-}
-
-export interface ItemStatByOrder {
-  itemId: number;
-  itemName: string;
   games: number;
   winRate: number;
   pickRate: number;
@@ -84,7 +76,6 @@ export interface ChampionPositionStats {
   runeBuilds: RuneBuildData[];
   skillBuilds: SkillBuildData[];
   spellStats: SpellStatsData[];
-  itemStatsByOrder: Record<string, ItemStatByOrder[]>;
 }
 
 export interface ChampionStatsResponse {

--- a/src/entities/champion/types.ts
+++ b/src/entities/champion/types.ts
@@ -45,9 +45,6 @@ export interface RuneBuildData {
   primaryPerk3: number;
   subPerk0: number;
   subPerk1: number;
-  statPerkDefense: number;
-  statPerkFlex: number;
-  statPerkOffense: number;
   games: number;
   winRate: number;
   pickRate: number;

--- a/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
+++ b/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  BootBuildStats,
   ChampionOverview,
   ItemBuildStats,
   MatchupStats,
@@ -126,6 +127,7 @@ export default function ChampionStatsDetailPageClient({
                 />
               </div>
               <ItemBuildStats data={currentPositionStats.itemBuilds} startItemBuilds={currentPositionStats.startItemBuilds} />
+              <BootBuildStats data={currentPositionStats.bootBuilds} />
               <RuneStats data={currentPositionStats.runeBuilds} />
               <MatchupStats data={currentPositionStats.matchups ?? []} />
             </>

--- a/src/widgets/champion-stats-panel/index.ts
+++ b/src/widgets/champion-stats-panel/index.ts
@@ -1,6 +1,7 @@
 export { default as ChampionListSidebar } from "./ui/ChampionListSidebar";
 export { default as ChampionOverview } from "./ui/ChampionOverview";
 export { default as ItemBuildStats } from "./ui/ItemBuildStats";
+export { default as BootBuildStats } from "./ui/BootBuildStats";
 export { default as MatchupStats } from "./ui/MatchupStats";
 export { default as PositionTabs } from "./ui/PositionTabs";
 export { default as PositionTabsList } from "./ui/PositionTabsList";

--- a/src/widgets/champion-stats-panel/ui/BootBuildStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/BootBuildStats.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { GameTooltip } from "@/shared/ui/tooltip";
+import type { BootBuildData } from "@/entities/champion";
+import { getItemImageUrl } from "@/shared/lib/game";
+import Image from "next/image";
+
+interface BootBuildStatsProps {
+  data: BootBuildData[];
+}
+
+export default function BootBuildStats({ data }: BootBuildStatsProps) {
+  if (!data || data.length === 0) return null;
+
+  return (
+    <div className="bg-surface-1 rounded-lg border border-divider p-0 md:p-5">
+      <h3 className="text-base font-bold text-on-surface p-2">신발 빌드</h3>
+      <div className="space-y-2">
+        {data.map((build, i) => (
+          <BuildRow
+            key={i}
+            bootId={build.bootId}
+            winRate={build.winRate}
+            games={build.games}
+            pickRate={build.pickRate}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BuildRow({
+  bootId,
+  winRate,
+  games,
+  pickRate,
+}: {
+  bootId: number;
+  winRate: number;
+  games: number;
+  pickRate: number;
+}) {
+  const winRatePercent = winRate * 100;
+  return (
+    <div className="flex items-center gap-3 bg-surface rounded-lg px-3 py-2">
+      <GameTooltip type="item" id={bootId}>
+        <Image
+          src={getItemImageUrl(bootId)}
+          alt={`item-${bootId}`}
+          width={36}
+          height={36}
+          className="rounded border border-divider"
+          unoptimized
+        />
+      </GameTooltip>
+      <div className="flex items-center gap-4 ml-auto text-xs">
+        <span>
+          <span className="text-on-surface-medium">승률 </span>
+          <span
+            className={`font-medium ${winRatePercent >= 50 ? "text-win" : "text-loss"
+              }`}
+          >
+            {winRatePercent.toFixed(1)}%
+          </span>
+        </span>
+        <span>
+          <span className="text-on-surface-medium">픽률 </span>
+          <span className="font-medium text-on-surface">
+            {(pickRate * 100).toFixed(1)}%
+          </span>
+        </span>
+        <span className="text-on-surface-medium">
+          {games.toLocaleString()}게임
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/champion-stats-panel/ui/RuneStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/RuneStats.tsx
@@ -4,9 +4,6 @@ import { GameTooltip } from "@/shared/ui/tooltip";
 import {
   RUNE_TREE_MAP,
   KEYSTONE_NAMES,
-  STAT_PERK_NAMES,
-  STAT_PERK_ROWS,
-  STAT_PERK_ROW_KEYS,
 } from "@/shared/constants/runes";
 import type { RuneBuildData } from "@/entities/champion";
 import { getPerkImageUrl } from "@/shared/lib/game";
@@ -171,45 +168,6 @@ function RuneTreeSection({
   );
 }
 
-/* ─── 스탯 퍼크 행 컴포넌트 ─── */
-function StatPerkRow({
-  perks,
-  selectedPerkId,
-}: {
-  perks: number[];
-  selectedPerkId: number;
-}) {
-  return (
-    <div className="flex items-center gap-1.5">
-      {perks.map((perkId) => {
-        const isSelected = perkId === selectedPerkId;
-        return (
-          <GameTooltip
-            key={perkId}
-            type="rune"
-            id={perkId}
-            disabled={!isSelected}
-          >
-            <div
-              className={`w-5 h-5 rounded-full overflow-hidden relative bg-surface-8 ${isSelected ? "ring-1 ring-white/30" : "opacity-25 grayscale"
-                }`}
-            >
-              <Image
-                src={getPerkImageUrl(perkId)}
-                alt={STAT_PERK_NAMES[perkId] ?? `Perk ${perkId}`}
-                fill
-                sizes="20px"
-                className="object-cover"
-                unoptimized
-              />
-            </div>
-          </GameTooltip>
-        );
-      })}
-    </div>
-  );
-}
-
 /* ─── 룬 페이지 행 (빌드 1개) ─── */
 function RunePageRow({ build }: { build: RuneBuildData }) {
   const primaryPerkIds = [
@@ -233,37 +191,12 @@ function RunePageRow({ build }: { build: RuneBuildData }) {
           isPrimary
         />
 
-        {/* 서브룬 트리 + 룬 파편 */}
-        <div className="flex flex-col items-center gap-3">
-          <RuneTreeSection
-            treeId={build.subStyleId}
-            selectedPerkIds={allSelectedIds}
-            isPrimary={false}
-          />
-
-          {/* 룬 파편 */}
-          <div className="flex flex-col items-center gap-1.5">
-            <span className="text-[9px] text-on-surface-medium mb-0.5">
-              룬 파편
-            </span>
-            {STAT_PERK_ROWS.map((row, rowIdx) => {
-              const key = STAT_PERK_ROW_KEYS[rowIdx];
-              const perkMap: Record<string, number> = {
-                offense: build.statPerkOffense,
-                flex: build.statPerkFlex,
-                defense: build.statPerkDefense,
-              };
-              const selectedId = perkMap[key] ?? 0;
-              return (
-                <StatPerkRow
-                  key={key}
-                  perks={row.perks}
-                  selectedPerkId={selectedId}
-                />
-              );
-            })}
-          </div>
-        </div>
+        {/* 서브룬 트리. 룬 파편은 BE BigQuery 미적재로 임시 제거 (MP-8) */}
+        <RuneTreeSection
+          treeId={build.subStyleId}
+          selectedPerkIds={allSelectedIds}
+          isPrimary={false}
+        />
       </div>
 
       {/* 승률/픽률/게임수 */}

--- a/src/widgets/champion-stats-panel/ui/SkillTreeStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/SkillTreeStats.tsx
@@ -20,6 +20,16 @@ const SKILL_COLORS: Record<string, string> = {
 };
 
 function normalizeSkills(skillBuild: string): string[] {
+  if (skillBuild.trim().startsWith("[")) {
+    try {
+      const arr = JSON.parse(skillBuild);
+      if (Array.isArray(arr)) {
+        return arr.map((s) => SLOT_TO_SKILL[String(s)] ?? String(s));
+      }
+    } catch {
+      // fall through to legacy parser
+    }
+  }
   return skillBuild.split(",").map((s) => SLOT_TO_SKILL[s] ?? s);
 }
 


### PR DESCRIPTION
## Summary
- 백엔드 `feature/MP-8-bigquery-stats-module`에서 `GET /api/v1/{platformId}/champion-stats` 응답에 추가된 `bootBuilds[]` 필드 수신·표시
- `ChampionPositionStats.bootBuilds: BootBuildData[]` 타입 추가
- `BootBuildStats` 위젯 신규 (`ItemBuildStats`의 `BuildRow` 패턴 차용) — 챔피언 통계 상세 페이지 `ItemBuildStats`와 `RuneStats` 사이에 슬롯

## Backend
- 대응 브랜치: `feature/MP-8-bigquery-stats-module`

## 가정 / 보고 사항
- **부츠 아이콘 경로**: 기존 `getItemImageUrl(bootId)` (`static.metapick.me/items/{bootId}.png`) 재사용. 신발 ID(3006/3009/3047/3158/3111/3020/3117 등)가 일반 아이템과 동일 경로에서 서빙된다고 가정. 다른 디렉터리(`/boots/`)에 호스팅된다면 헬퍼 분기 필요.
- `bootBuilds`가 빈 배열이거나 누락된 응답을 받으면 `BootBuildStats`가 `null`을 반환해 섹션이 숨겨짐 (다른 형제 섹션과 동일 패턴).
- 현재 저장소에 hardcoded champion-stats fixture / storybook이 없어 모킹 추가 없음.
- 단위 테스트 인프라가 없어(`package.json`에 `test` script 없음, `__tests__` 디렉터리 없음) lint + typecheck만 수행. 둘 다 클린 통과.

## Out of scope
- husky pre-commit / next/image host 정렬 수정은 별도 브랜치(`feature/nvalid-src-prop-https-static-metapick-me-zesty-flurry`)에서 처리 중. 그 PR 머지 전까지는 이 브랜치 위에서 `.husky/pre-commit`이 남아 있으나, 이번 변경 파일은 `.ts/.tsx`라 lint-staged 매처(`*.{js,css,md}`)에 걸리지 않아 커밋 가능.

## Test plan
- [ ] BE develop 머지 후 수동: 챔피언 상세 페이지에서 "신발 빌드" 섹션이 정상 노출되는지 확인 (TOP/JG/MID/ADC/SUP 5개 포지션 전부)
- [ ] `bootBuilds`가 빈 배열인 케이스에서 섹션이 사라지는지 확인
- [ ] 부츠 아이콘 Network 200 확인 (만약 404 → 호스트 경로 가정 재검토 필요)
- [ ] 다른 빌드 섹션(아이템/룬/스킬/매치업) 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)