### PR TITLE
feat(champion-stats): MatchupData rankType 도입

### DIFF
--- a/src/entities/champion/types.ts
+++ b/src/entities/champion/types.ts
@@ -9,6 +9,7 @@ export type PositionType = "TOP" | "JUNGLE" | "MID" | "ADC" | "SUPPORT";
 export type ApiPositionType = "TOP" | "JUNGLE" | "MIDDLE" | "BOTTOM" | "UTILITY";
 
 export interface MatchupData {
+  rankType: "TOP" | "BOTTOM"; // TOP=잘 잡는 상대, BOTTOM=카운터
   opponentChampionId: number;
   games: number;
   winRate: number;

--- a/src/widgets/champion-stats-panel/ui/MatchupStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/MatchupStats.tsx
@@ -15,7 +15,7 @@ export default function MatchupStats({ data }: MatchupStatsProps) {
     () =>
       [...data]
         .filter((m) => m.winRate != null && m.games != null && m.opponentChampionId != null)
-        .filter((m) => m.winRate >= 0.5)
+        .filter((m) => m.rankType === "TOP")
         .sort((a, b) => b.winRate - a.winRate),
     [data]
   );
@@ -24,7 +24,7 @@ export default function MatchupStats({ data }: MatchupStatsProps) {
     () =>
       [...data]
         .filter((m) => m.winRate != null && m.games != null && m.opponentChampionId != null)
-        .filter((m) => m.winRate < 0.5)
+        .filter((m) => m.rankType === "BOTTOM")
         .sort((a, b) => a.winRate - b.winRate),
     [data]
   );


### PR DESCRIPTION
## Summary
- BE `feature/MP-8-bigquery-stats-module` 응답 통합(strong/weakMatchups → 단일 `matchups[]` + `rankType`) 대응
- `MatchupData`에 `rankType: "TOP" | "BOTTOM"` 추가
- `MatchupStats` 분류 기준을 `winRate >= 0.5` 임계 → `rankType === "TOP"/"BOTTOM"` 으로 교체

## 배경 / 영향
이전 FE는 백엔드가 보내지 않는 `strongMatchups`/`weakMatchups`를 기대하던 코드 흔적은 없고, 이미 `matchups[]`를 사용 중이었지만 **승률 50% 임계로 좌우 컬럼을 갈랐기 때문에** 50% 근방의 매치업이 잘못 분류되거나, 백엔드 정렬·집계 의도와 맞지 않는 결과가 노출되고 있었음. 이번 변경으로 백엔드의 분류 의도를 그대로 따른다.

## 의존성 / 머지 순서
- 같은 영역을 만지는 PR #148 (`feature/MP-8-champion-boot-builds`)이 먼저 머지되거나 이 PR이 먼저 머지되면 다른 쪽에 rebase가 필요. `types.ts` 충돌은 단순 병합 (`MatchupData` 필드 vs `RuneBuildData`/`itemStatsByOrder` 영역).

## Test plan
- [ ] 챔피언 상세 페이지: "유리한 상대" 컬럼에 `rankType=TOP` 5개, "불리한 상대" 컬럼에 `rankType=BOTTOM` 5개 표시 확인
- [ ] 50% 근방 매치업이 임계가 아닌 백엔드 분류대로 노출되는지 확인
- [ ] 빈 응답: "데이터 없음" 표시

## 참고 (백엔드)
- 캐시 prefix `champion-stats:v2:* → v3:*` bump 됨 (FE 무관, stale 역직렬화 방지용)
- `data[].champions[].tier`가 BQ 모드에서 `S+/S/A/B/C/D`로 바뀐 건은 `ChampionOverview.tsx:75`의 `Tier ${tier}` 템플릿이 그대로 자연스럽게 출력되어 별도 수정 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)