### PR TITLE
feat(champion-stats-filter): tier 누적(+) 옵션 + 전체 티어 노출

### DIFF
--- a/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
+++ b/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
@@ -5,21 +5,28 @@ import { useSeasonStore } from "@/entities/season";
 import { ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+// CHALLENGER+ 는 BE INVALID_TIER_FILTER이므로 의도적으로 제외
 const TIER_OPTIONS = [
   { value: "CHALLENGER", label: "챌린저" },
   { value: "GRANDMASTER", label: "그랜드마스터" },
+  { value: "GRANDMASTER+", label: "그랜드마스터+" },
   { value: "MASTER", label: "마스터" },
+  { value: "MASTER+", label: "마스터+" },
   { value: "DIAMOND", label: "다이아몬드" },
+  { value: "DIAMOND+", label: "다이아몬드+" },
   { value: "EMERALD", label: "에메랄드" },
+  { value: "EMERALD+", label: "에메랄드+" },
   { value: "PLATINUM", label: "플래티넘" },
+  { value: "PLATINUM+", label: "플래티넘+" },
   { value: "GOLD", label: "골드" },
+  { value: "GOLD+", label: "골드+" },
   { value: "SILVER", label: "실버" },
+  { value: "SILVER+", label: "실버+" },
   { value: "BRONZE", label: "브론즈" },
+  { value: "BRONZE+", label: "브론즈+" },
   { value: "IRON", label: "아이언" },
+  { value: "IRON+", label: "아이언+" },
 ] as const;
-
-// CHALLENGER는 최상위라 "+ 누적"이 의미 없고 BE가 INVALID_TIER_FILTER 400을 반환
-const CUMULATIVE_DISALLOWED = "CHALLENGER";
 
 interface ChampionStatsFiltersProps {
   selectedTier: string;
@@ -45,13 +52,6 @@ export default function ChampionStatsFilters({
   const patchRef = useRef<HTMLDivElement>(null);
   const platformRef = useRef<HTMLDivElement>(null);
 
-  const isCumulative = selectedTier.endsWith("+");
-  const baseTier = isCumulative ? selectedTier.slice(0, -1) : selectedTier;
-  const cumulativeDisabled = baseTier === CUMULATIVE_DISALLOWED;
-  const baseTierLabel =
-    TIER_OPTIONS.find((o) => o.value === baseTier)?.label ?? baseTier;
-  const tierDisplayLabel = isCumulative ? `${baseTierLabel}+` : baseTierLabel;
-
   const latestSeason = useSeasonStore((s) => s.getLatestSeason());
   const latestPatches = latestSeason?.patchVersions ?? [];
   const activePatch = selectedPatch || latestPatches[0] || "";
@@ -73,18 +73,6 @@ export default function ChampionStatsFilters({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [handleClickOutside]);
 
-  const handleTierSelect = (value: string) => {
-    const next =
-      isCumulative && value !== CUMULATIVE_DISALLOWED ? `${value}+` : value;
-    onTierChange(next);
-    setTierOpen(false);
-  };
-
-  const handleCumulativeToggle = () => {
-    if (cumulativeDisabled) return;
-    onTierChange(isCumulative ? baseTier : `${baseTier}+`);
-  };
-
   return (
     <div className="flex items-center justify-center gap-2 flex-wrap">
       {/* 티어 */}
@@ -92,11 +80,11 @@ export default function ChampionStatsFilters({
         <button
           type="button"
           onClick={() => setTierOpen((v) => !v)}
-          className="bg-surface-4 hover:bg-surface-8 border border-divider rounded-lg px-3 py-1.5 pr-8 text-sm font-medium text-on-surface cursor-pointer focus:outline-none min-w-[130px] text-left"
+          className="bg-surface-4 hover:bg-surface-8 border border-divider rounded-lg px-3 py-1.5 pr-8 text-sm font-medium text-on-surface cursor-pointer focus:outline-none min-w-[140px] text-left"
           aria-haspopup="listbox"
           aria-expanded={tierOpen}
         >
-          {tierDisplayLabel}
+          {TIER_OPTIONS.find((o) => o.value === selectedTier)?.label ?? selectedTier}
           <ChevronDown
             className={`absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-on-surface-medium transition-transform ${tierOpen ? "rotate-180" : ""}`}
           />
@@ -105,12 +93,15 @@ export default function ChampionStatsFilters({
           <div className="absolute top-full left-0 mt-1 w-full bg-surface-4 border border-divider rounded-lg shadow-lg z-50 overflow-hidden">
             <div className="py-1 max-h-[320px] overflow-y-auto" role="listbox" aria-label="티어 선택">
               {TIER_OPTIONS.map((opt) => {
-                const selected = opt.value === baseTier;
+                const selected = opt.value === selectedTier;
                 return (
                   <button
                     key={opt.value}
                     type="button"
-                    onClick={() => handleTierSelect(opt.value)}
+                    onClick={() => {
+                      onTierChange(opt.value);
+                      setTierOpen(false);
+                    }}
                     className={`w-full px-3 py-1.5 text-left text-sm transition-colors cursor-pointer ${
                       selected
                         ? "bg-surface-8 text-on-surface font-medium"
@@ -127,28 +118,6 @@ export default function ChampionStatsFilters({
           </div>
         )}
       </div>
-
-      {/* 누적(+) 토글: 선택 티어 이상 데이터 합산 */}
-      <button
-        type="button"
-        onClick={handleCumulativeToggle}
-        disabled={cumulativeDisabled}
-        aria-pressed={isCumulative}
-        title={
-          cumulativeDisabled
-            ? "챌린저는 누적(+) 옵션을 사용할 수 없습니다"
-            : "선택 티어 이상 누적"
-        }
-        className={`border rounded-lg px-3 py-1.5 text-sm font-medium focus:outline-none transition-colors min-w-[44px] ${
-          cumulativeDisabled
-            ? "bg-surface-4 border-divider text-on-surface-medium opacity-40 cursor-not-allowed"
-            : isCumulative
-              ? "bg-primary/15 border-primary text-primary cursor-pointer"
-              : "bg-surface-4 border-divider text-on-surface hover:bg-surface-8 cursor-pointer"
-        }`}
-      >
-        +
-      </button>
 
       {/* 패치 */}
       {latestPatches.length > 0 && (

--- a/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
+++ b/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
@@ -9,7 +9,17 @@ const TIER_OPTIONS = [
   { value: "CHALLENGER", label: "챌린저" },
   { value: "GRANDMASTER", label: "그랜드마스터" },
   { value: "MASTER", label: "마스터" },
+  { value: "DIAMOND", label: "다이아몬드" },
+  { value: "EMERALD", label: "에메랄드" },
+  { value: "PLATINUM", label: "플래티넘" },
+  { value: "GOLD", label: "골드" },
+  { value: "SILVER", label: "실버" },
+  { value: "BRONZE", label: "브론즈" },
+  { value: "IRON", label: "아이언" },
 ] as const;
+
+// CHALLENGER는 최상위라 "+ 누적"이 의미 없고 BE가 INVALID_TIER_FILTER 400을 반환
+const CUMULATIVE_DISALLOWED = "CHALLENGER";
 
 interface ChampionStatsFiltersProps {
   selectedTier: string;
@@ -35,6 +45,13 @@ export default function ChampionStatsFilters({
   const patchRef = useRef<HTMLDivElement>(null);
   const platformRef = useRef<HTMLDivElement>(null);
 
+  const isCumulative = selectedTier.endsWith("+");
+  const baseTier = isCumulative ? selectedTier.slice(0, -1) : selectedTier;
+  const cumulativeDisabled = baseTier === CUMULATIVE_DISALLOWED;
+  const baseTierLabel =
+    TIER_OPTIONS.find((o) => o.value === baseTier)?.label ?? baseTier;
+  const tierDisplayLabel = isCumulative ? `${baseTierLabel}+` : baseTierLabel;
+
   const latestSeason = useSeasonStore((s) => s.getLatestSeason());
   const latestPatches = latestSeason?.patchVersions ?? [];
   const activePatch = selectedPatch || latestPatches[0] || "";
@@ -56,6 +73,18 @@ export default function ChampionStatsFilters({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [handleClickOutside]);
 
+  const handleTierSelect = (value: string) => {
+    const next =
+      isCumulative && value !== CUMULATIVE_DISALLOWED ? `${value}+` : value;
+    onTierChange(next);
+    setTierOpen(false);
+  };
+
+  const handleCumulativeToggle = () => {
+    if (cumulativeDisabled) return;
+    onTierChange(isCumulative ? baseTier : `${baseTier}+`);
+  };
+
   return (
     <div className="flex items-center justify-center gap-2 flex-wrap">
       {/* 티어 */}
@@ -67,7 +96,7 @@ export default function ChampionStatsFilters({
           aria-haspopup="listbox"
           aria-expanded={tierOpen}
         >
-          {TIER_OPTIONS.find((o) => o.value === selectedTier)?.label ?? selectedTier}
+          {tierDisplayLabel}
           <ChevronDown
             className={`absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-on-surface-medium transition-transform ${tierOpen ? "rotate-180" : ""}`}
           />
@@ -76,15 +105,12 @@ export default function ChampionStatsFilters({
           <div className="absolute top-full left-0 mt-1 w-full bg-surface-4 border border-divider rounded-lg shadow-lg z-50 overflow-hidden">
             <div className="py-1 max-h-[320px] overflow-y-auto" role="listbox" aria-label="티어 선택">
               {TIER_OPTIONS.map((opt) => {
-                const selected = opt.value === selectedTier;
+                const selected = opt.value === baseTier;
                 return (
                   <button
                     key={opt.value}
                     type="button"
-                    onClick={() => {
-                      onTierChange(opt.value);
-                      setTierOpen(false);
-                    }}
+                    onClick={() => handleTierSelect(opt.value)}
                     className={`w-full px-3 py-1.5 text-left text-sm transition-colors cursor-pointer ${
                       selected
                         ? "bg-surface-8 text-on-surface font-medium"
@@ -101,6 +127,28 @@ export default function ChampionStatsFilters({
           </div>
         )}
       </div>
+
+      {/* 누적(+) 토글: 선택 티어 이상 데이터 합산 */}
+      <button
+        type="button"
+        onClick={handleCumulativeToggle}
+        disabled={cumulativeDisabled}
+        aria-pressed={isCumulative}
+        title={
+          cumulativeDisabled
+            ? "챌린저는 누적(+) 옵션을 사용할 수 없습니다"
+            : "선택 티어 이상 누적"
+        }
+        className={`border rounded-lg px-3 py-1.5 text-sm font-medium focus:outline-none transition-colors min-w-[44px] ${
+          cumulativeDisabled
+            ? "bg-surface-4 border-divider text-on-surface-medium opacity-40 cursor-not-allowed"
+            : isCumulative
+              ? "bg-primary/15 border-primary text-primary cursor-pointer"
+              : "bg-surface-4 border-divider text-on-surface hover:bg-surface-8 cursor-pointer"
+        }`}
+      >
+        +
+      </button>
 
       {/* 패치 */}
       {latestPatches.length > 0 && (


### PR DESCRIPTION
## Summary
- BE `feature/MP-8-bigquery-stats-module`의 `tier` 파라미터 확장(`{TIER}+` = 해당 티어 이상 누적) 대응
- `TIER_OPTIONS`를 기존 3개(`CHALLENGER/GRANDMASTER/MASTER`) → IRON~CHALLENGER 10단계 전체로 확장
- 누적(`+`) 토글 버튼 신규 — 활성 시 `selectedTier`를 `"{TIER}+"`로 보내 BE에서 누적 합산
- `CHALLENGER+`는 BE `INVALID_TIER_FILTER`이므로 토글 비활성화 + 자동 보정

## UX
- 티어 드롭다운 옆 작은 `+` 버튼이 단일/누적을 토글
  - 비활성: 단일 티어 (`MASTER` → MASTER만)
  - 활성: 누적 (`MASTER+` → MASTER 이상 합산)
- CHALLENGER 선택 시 토글 disabled (opacity-40), `title`로 사유 안내
- 누적 ON 상태에서 CHALLENGER 선택 시 자동으로 `+` 제거 (handleTierSelect 가드)
- 선택 표시(드롭다운 highlight)는 `baseTier` 기준 매칭

## 백엔드 인코딩
axios가 `+`를 `%2B`로 인코딩 → BE에서 그대로 `MASTER+`로 디코딩됨. BE의 RFC 1866 폴백 경로(공백→`+`) 미사용. 별도 처리 불필요.

## Test plan
- [ ] MASTER 선택 → `?tier=MASTER` 요청 / `+` 토글 ON → `?tier=MASTER%2B` 요청 확인
- [ ] CHALLENGER 선택 시 `+` 버튼 disabled 시각/클릭 확인
- [ ] `+` ON 상태에서 CHALLENGER 클릭 → 자동으로 `+` OFF 되어 `?tier=CHALLENGER` 송신
- [ ] 모든 10개 티어가 드롭다운에 노출, 한글 라벨 정상
- [ ] 외부 클릭으로 드롭다운 닫힘, 토글 버튼 클릭은 드롭다운에 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)