### PR TITLE
fix(champion-stats): itemBuild/startItems 응답 타입을 number[]로 정정

### DIFF
--- a/src/entities/champion/types.ts
+++ b/src/entities/champion/types.ts
@@ -16,14 +16,14 @@ export interface MatchupData {
 }
 
 export interface ItemBuildData {
-  itemBuild: string; // "3078,3053,3065"
+  itemBuild: number[]; // [3078, 3053, 3065]
   games: number;
   winRate: number;
   pickRate: number;
 }
 
 export interface StartItemBuildData {
-  startItems: string; // "1054,2003"
+  startItems: number[]; // [1054, 2003]
   games: number;
   winRate: number;
   pickRate: number;

--- a/src/widgets/champion-stats-panel/ui/ItemBuildStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/ItemBuildStats.tsx
@@ -22,21 +22,15 @@ export default function ItemBuildStats({ data, startItemBuilds }: ItemBuildStats
           <div>
             <h4 className="text-sm font-medium text-on-surface-medium mb-2 p-2">시작 아이템</h4>
             <div className="space-y-2">
-              {startItemBuilds.map((build, i) => {
-                const itemIds = build.startItems
-                  .split(",")
-                  .map(Number)
-                  .filter(Boolean);
-                return (
-                  <BuildRow
-                    key={i}
-                    itemIds={itemIds}
-                    winRate={build.winRate}
-                    games={build.games}
-                    pickRate={build.pickRate}
-                  />
-                );
-              })}
+              {startItemBuilds.map((build, i) => (
+                <BuildRow
+                  key={i}
+                  itemIds={build.startItems}
+                  winRate={build.winRate}
+                  games={build.games}
+                  pickRate={build.pickRate}
+                />
+              ))}
             </div>
           </div>
         )}
@@ -45,21 +39,15 @@ export default function ItemBuildStats({ data, startItemBuilds }: ItemBuildStats
           <div>
             <h4 className="text-sm font-medium text-on-surface-medium mb-2 p-2">코어 빌드</h4>
             <div className="space-y-2">
-              {data.map((build, i) => {
-                const itemIds = build.itemBuild
-                  .split(",")
-                  .map(Number)
-                  .filter(Boolean);
-                return (
-                  <BuildRow
-                    key={i}
-                    itemIds={itemIds}
-                    winRate={build.winRate}
-                    games={build.games}
-                    pickRate={build.pickRate}
-                  />
-                );
-              })}
+              {data.map((build, i) => (
+                <BuildRow
+                  key={i}
+                  itemIds={build.itemBuild}
+                  winRate={build.winRate}
+                  games={build.games}
+                  pickRate={build.pickRate}
+                />
+              ))}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- BE `feature/MP-8-bigquery-stats-module` `c34ef76` 응답 shape 변경 대응
- `ItemBuildData.itemBuild`, `StartItemBuildData.startItems`를 `string` → `number[]`로 정정
- `ItemBuildStats.tsx`의 두 군데 `.split(",").map(Number).filter(Boolean)` 파싱 제거, 배열 직접 전달

## 진짜 원인 (그 동안 시작 아이템/코어 빌드가 화면에 안 보이던 이유)
BE BQ 어댑터가 `"[3161,6699,6694]"` 형태의 JSON 문자열을 그대로 내려보냈고, FE는 콤마 split을 했다.

```
"[3161,6699,6694]".split(",")  → ["[3161", "6699", "6694]"]
.map(Number)                    → [NaN, 6699, NaN]
.filter(Boolean)                → [6699]   // 양 끝 토큰 손실
```

→ 1코어/3코어가 항상 사라지거나, 2-아이템 시작템(`"[1101,2003]"`)은 모든 요소가 NaN이 되어 `[]` 반환. 결과적으로 빌드 카드가 비어 보임. 직전 진단의 "데이터 양 부족"은 일부만 맞고, 사실 정상 응답에서도 FE가 깨고 있었다.

BE가 `List<Integer>`로 직렬화하면서 FE의 사후처리는 그냥 제거하면 끝.

## 변경 파일
- `src/entities/champion/types.ts:18-30` — 두 인터페이스 필드 타입 교체
- `src/widgets/champion-stats-panel/ui/ItemBuildStats.tsx:25-39, 46-53` — `.split(...)` 블록 → 배열 직접 전달, JSX 단순화

검증: `pnpm lint` 0 errors (기존 5 warnings 무관), `tsc --noEmit` 클린.

## 의존성 / 머지 순서
- 기존 PR #148 (boots + statPerk 임시 제거 + skillBuild JSON 파서)와 **별개**. 둘 다 `types.ts`를 만지지만 변경 위치가 달라(이건 ItemBuildData/StartItemBuildData, #148은 RuneBuildData/itemStatsByOrder/SkillBuildData) 충돌 없음.
- PR #149 (matchups rankType), #150 (tier filter +) 와도 무관.
- 어느 순서로 머지해도 OK.

## Test plan
- [ ] BE 재빌드 + Aatrox/16.5/EMERALD+/TOP 케이스로 검증:
  ```bash
  curl -s 'http://localhost:8100/api/v1/kr/champion-stats?championId=266&patch=16.5&tier=EMERALD%2B' \
    | jq '.data.positions[0] | {start: .startItemBuilds[0].startItems, item: .itemBuilds[0].itemBuild}'
  ```
  기대: `{"start": [...], "item": [...]}` (따옴표 없는 숫자 배열)
- [ ] 챔피언 상세 페이지 "시작 아이템" / "코어 빌드" 카드에 아이템 아이콘 정상 노출 확인
- [ ] 빈 배열 응답에서는 섹션이 사라지는 기존 동작 유지

## 참고
- skillBuild는 본 변경 범위 아님. BQ `null` 포함 + ClickHouse legacy 호환 이슈로 별도 추후 검토 (BE 측 안내 그대로).
- matchups, bootBuilds는 정상이라 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)