### PR TITLE
fix(champion-stats): MP-XXX 티어 라벨 색상 매핑 갱신 (S+/S/A/B/C/D)

### DIFF
--- a/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
@@ -13,12 +13,12 @@ import { useGameDataStore } from "@/shared/model/game-data";
 import Image from "next/image";
 
 const TIER_COLORS: Record<string, string> = {
-  OP: "bg-red-500 text-white",
-  "1": "bg-orange-500 text-white",
-  "2": "bg-yellow-500 text-surface",
-  "3": "bg-green-500 text-white",
-  "4": "bg-blue-500 text-white",
-  "5": "bg-gray-500 text-white",
+  "S+": "bg-red-500 text-white",
+  S: "bg-orange-500 text-white",
+  A: "bg-yellow-500 text-surface",
+  B: "bg-green-500 text-white",
+  C: "bg-blue-500 text-white",
+  D: "bg-gray-500 text-white",
 };
 
 const SKILL_KEYS = ["Q", "W", "E", "R"] as const;
@@ -69,10 +69,10 @@ export default function ChampionOverview({
         <div className="self-start">
           <span
             className={`px-2 py-0.5 text-xs font-bold rounded ${
-              TIER_COLORS[tier] || TIER_COLORS["5"]
+              TIER_COLORS[tier] || TIER_COLORS["D"]
             }`}
           >
-            {tier === "OP" ? "OP" : `Tier ${tier}`}
+            {tier}
           </span>
         </div>
         {/* 승리 */}

--- a/src/widgets/champion-stats-panel/ui/ChampionStatsTable.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionStatsTable.tsx
@@ -8,12 +8,12 @@ import Link from "next/link";
 import { useMemo } from "react";
 
 const TIER_COLORS: Record<string, string> = {
-  OP: "bg-red-500 text-white",
-  "1": "bg-orange-500 text-white",
-  "2": "bg-yellow-500 text-surface",
-  "3": "bg-green-500 text-white",
-  "4": "bg-blue-500 text-white",
-  "5": "bg-gray-500 text-white",
+  "S+": "bg-red-500 text-white",
+  S: "bg-orange-500 text-white",
+  A: "bg-yellow-500 text-surface",
+  B: "bg-green-500 text-white",
+  C: "bg-blue-500 text-white",
+  D: "bg-gray-500 text-white",
 };
 
 interface ChampionStatsTableProps {
@@ -66,7 +66,7 @@ export default function ChampionStatsTable({
             const championId = info?.id ?? "";
             const winRatePercent = entry.winRate * 100;
 
-            const tierColor = TIER_COLORS[entry.tier] ?? "bg-gray-500 text-white";
+            const tierColor = TIER_COLORS[entry.tier] ?? TIER_COLORS["D"];
 
             const content = (
               <>


### PR DESCRIPTION
## Summary

- 서버 응답의 티어 라벨이 `OP/1-5` → `S+/S/A/B/C/D`로 바뀌면서 `TIER_COLORS` 매핑이 모두 미스되어 회색 폴백만 노출되던 문제 수정
- `ChampionStatsTable.tsx`, `ChampionOverview.tsx` 두 곳의 매핑 키와 폴백을 새 라벨에 맞게 갱신
- `ChampionOverview` 배지 텍스트는 `Tier 1` 같은 framing 대신 티어 문자(S+/S/A/B/C/D)를 그대로 표시

서버 측은 `ChampionStatsBigQuerySqls.java:304-310`에서 이미 새 라벨을 반환하도록 전환되어 있음 (lol-server 측 변경 확인됨).

## Test plan

- [ ] /champion-stats 진입 → 챔피언별 티어 색상이 S+/S/A/B/C/D 별로 빨강/주황/노랑/초록/파랑/회색으로 정상 노출되는지
- [ ] /champion-stats/[championId] 상세 페이지 상단 배지가 `S+`/`S`/`A`/... 텍스트로 표시되는지
- [ ] 알 수 없는 라벨이 들어와도 회색(D) 폴백으로 떨어지는지

🤖 Generated by Padosol