### PR TITLE
chore: MP-XXX lint-staged 검증 대상을 JS/TS만으로 좁힘

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "zustand": "^5.0.11"
   },
   "lint-staged": {
-    "*.js": "eslint --fix",
-    "*.{js,css,md}": "prettier --write"
+    "*.{js,jsx,ts,tsx}": "eslint --fix"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",


### PR DESCRIPTION
## Summary

- 기존 `*.{js,css,md}: prettier --write` 룰이 prettier 의존성 없이 등록되어 있어 `.md` 등 변경 시 pre-commit 훅이 ENOENT로 실패
- 정책상 `.md`/`.css` 자동 포맷이 필요 없으므로 prettier 라인 제거
- 동시에 `*.js` → `*.{js,jsx,ts,tsx}`로 패턴을 넓혀 TypeScript 변경도 커밋 시 ESLint 검증되도록 정렬

```diff
 "lint-staged": {
-  "*.js": "eslint --fix",
-  "*.{js,css,md}": "prettier --write"
+  "*.{js,jsx,ts,tsx}": "eslint --fix"
 }
```

## Test plan

- [ ] `.tsx` 파일 수정 후 커밋 → ESLint --fix가 동작하는지 확인
- [ ] `.md` 파일 수정 후 커밋 → 훅이 통과하는지 (matching task 없음 메시지)
- [ ] `husky install` 재설치 없이 즉시 적용되는지

🤖 Generated by Padosol