### PR TITLE
feat(champion-stats): MP-9 상세 페이지 정보 밀도 보강 + 시간대별 차트

### DIFF
--- a/src/entities/champion/api/championTimelineApi.ts
+++ b/src/entities/champion/api/championTimelineApi.ts
@@ -1,0 +1,21 @@
+import type { AxiosInstance } from "axios";
+import { apiClient } from "@/shared/api/client";
+import type { ApiResponse } from "@/shared/api/types";
+import type { ChampionTimelineResponse } from "../types";
+
+export async function getChampionTimeline(
+  region: string,
+  championId: string,
+  patch: string,
+  tier?: string,
+  client: AxiosInstance = apiClient
+): Promise<ChampionTimelineResponse> {
+  const response = await client.get<ApiResponse<ChampionTimelineResponse>>(
+    `/v1/${region}/champion-stats/timeline`,
+    { params: { championId, patch, ...(tier && { tier }) } }
+  );
+  if (response.data.result === "FAIL") {
+    throw new Error(response.data.errorMessage || "챔피언 타임라인 조회에 실패했습니다.");
+  }
+  return response.data.data;
+}

--- a/src/entities/champion/index.ts
+++ b/src/entities/champion/index.ts
@@ -11,6 +11,7 @@ export type {
   ChampionRotationResponse, PositionType, MatchupData,
   ItemBuildData, StartItemBuildData, BootBuildData, RuneBuildData, SkillBuildData,
   SpellStatsData,
+  ChampionAverageStats,
   ChampionPositionStats, ChampionStatsResponse,
   ApiPositionType, PositionChampionEntry, PositionChampionStats,
 } from "./types";

--- a/src/entities/champion/index.ts
+++ b/src/entities/champion/index.ts
@@ -6,6 +6,7 @@ export { useChampionStats } from "./model/useChampionStats";
 export { useChampionPositionStats } from "./model/useChampionPositionStats";
 export { getChampionById, getChampionsByIds, getChampionImageUrl, getChampionNameByEnglishName } from "./lib/championImage";
 export { WIN_RATE_COLOR_CLASSES, getWinRateTextClass, calcWinRateCeil2 } from "./lib/championStatsUtils";
+export { getTierBadgeClass } from "./lib/tierBadge";
 export type {
   ChampionRotationResponse, PositionType, MatchupData,
   ItemBuildData, StartItemBuildData, BootBuildData, RuneBuildData, SkillBuildData,

--- a/src/entities/champion/index.ts
+++ b/src/entities/champion/index.ts
@@ -1,9 +1,11 @@
 export { getChampionRotate } from "./api/championApi";
 export { getChampionStats } from "./api/championStatsApi";
 export { getChampionPositionStats } from "./api/championPositionStatsApi";
+export { getChampionTimeline } from "./api/championTimelineApi";
 export { useChampionRotate } from "./model/useChampionRotate";
 export { useChampionStats } from "./model/useChampionStats";
 export { useChampionPositionStats } from "./model/useChampionPositionStats";
+export { useChampionTimeline } from "./model/useChampionTimeline";
 export { getChampionById, getChampionsByIds, getChampionImageUrl, getChampionNameByEnglishName } from "./lib/championImage";
 export { WIN_RATE_COLOR_CLASSES, getWinRateTextClass, calcWinRateCeil2 } from "./lib/championStatsUtils";
 export { getTierBadgeClass } from "./lib/tierBadge";
@@ -14,4 +16,5 @@ export type {
   ChampionAverageStats,
   ChampionPositionStats, ChampionStatsResponse,
   ApiPositionType, PositionChampionEntry, PositionChampionStats,
+  TimelineFrame, PositionTimeline, ChampionTimelineResponse,
 } from "./types";

--- a/src/entities/champion/lib/tierBadge.ts
+++ b/src/entities/champion/lib/tierBadge.ts
@@ -1,0 +1,14 @@
+// 챔피언 티어 배지 컬러 — 상위 티어는 골드/녹색 톤, 하위는 회색/블루.
+// 패배(loss) 색은 빨강이므로 배지에서는 빨강을 쓰지 않는다.
+const TIER_BADGE_COLORS: Record<string, string> = {
+  "S+": "bg-gold text-surface",
+  S: "bg-amber-400 text-surface",
+  A: "bg-emerald-500 text-white",
+  B: "bg-teal-500 text-white",
+  C: "bg-blue-500 text-white",
+  D: "bg-gray-500 text-white",
+};
+
+export function getTierBadgeClass(tier: string): string {
+  return TIER_BADGE_COLORS[tier] ?? TIER_BADGE_COLORS["D"];
+}

--- a/src/entities/champion/model/useChampionTimeline.ts
+++ b/src/entities/champion/model/useChampionTimeline.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { getChampionTimeline } from "../api/championTimelineApi";
+import type { ChampionTimelineResponse } from "../types";
+
+export function useChampionTimeline(
+  championKey: string,
+  patch: string,
+  tier?: string,
+  region: string = "kr"
+) {
+  return useQuery<ChampionTimelineResponse, Error>({
+    queryKey: ["champion-timeline", championKey, patch, tier, region],
+    queryFn: () => getChampionTimeline(region, championKey, patch, tier),
+    enabled: !!championKey && !!patch,
+    staleTime: 30 * 60 * 1000,
+  });
+}

--- a/src/entities/champion/types.ts
+++ b/src/entities/champion/types.ts
@@ -16,28 +16,36 @@ export interface MatchupData {
   pickRate: number;
 }
 
-export interface ItemBuildData {
+// 모든 빌드 타입 공통 신뢰도 메타 (server M2 도입).
+// games 와 sampleSize 는 동일값이지만 sampleSize 가 의미명 명확.
+export interface BuildConfidenceMeta {
+  sampleSize?: number;
+  totalSampleSize?: number;
+  confidenceLowerBound?: number; // Wilson 95% lower bound, 0~1
+}
+
+export interface ItemBuildData extends BuildConfidenceMeta {
   itemBuild: number[]; // [3078, 3053, 3065]
   games: number;
   winRate: number;
   pickRate: number;
 }
 
-export interface StartItemBuildData {
+export interface StartItemBuildData extends BuildConfidenceMeta {
   startItems: number[]; // [1054, 2003]
   games: number;
   winRate: number;
   pickRate: number;
 }
 
-export interface BootBuildData {
+export interface BootBuildData extends BuildConfidenceMeta {
   bootId: number;
   games: number;
   winRate: number;
   pickRate: number;
 }
 
-export interface RuneBuildData {
+export interface RuneBuildData extends BuildConfidenceMeta {
   primaryStyleId: number;
   subStyleId: number;
   primaryPerk0: number;
@@ -51,14 +59,14 @@ export interface RuneBuildData {
   pickRate: number;
 }
 
-export interface SkillBuildData {
+export interface SkillBuildData extends BuildConfidenceMeta {
   skillBuild: string; // BQ: "[1,2,1,2,2,3,...]" / 레거시: "Q,E,W,Q,Q,R,..."
   games: number;
   winRate: number;
   pickRate: number;
 }
 
-export interface SpellStatsData {
+export interface SpellStatsData extends BuildConfidenceMeta {
   summoner1Id: number;
   summoner2Id: number;
   games: number;

--- a/src/entities/champion/types.ts
+++ b/src/entities/champion/types.ts
@@ -119,3 +119,22 @@ export interface PositionChampionStats {
   teamPosition: ApiPositionType;
   champions: PositionChampionEntry[];
 }
+
+export interface TimelineFrame {
+  minute: number; // 10/15/20/25/30
+  avgGold: number;
+  avgCs: number;
+  avgXp: number;
+  sampleSize: number;
+}
+
+export interface PositionTimeline {
+  teamPosition: ApiPositionType;
+  frames: TimelineFrame[];
+}
+
+export interface ChampionTimelineResponse {
+  championId: number;
+  tier: string;
+  positions: PositionTimeline[];
+}

--- a/src/entities/champion/types.ts
+++ b/src/entities/champion/types.ts
@@ -66,10 +66,25 @@ export interface SpellStatsData {
   pickRate: number;
 }
 
+export interface ChampionAverageStats {
+  teamPosition: string;
+  avgKills: number;
+  avgDeaths: number;
+  avgAssists: number;
+  kda: number;
+  avgGoldPerMinute: number;
+  avgLaneCs10m: number;
+  avgJungleCs10m: number;
+}
+
 export interface ChampionPositionStats {
   teamPosition: ApiPositionType;
   winRate: number;
   totalGames: number;
+  pickRate?: number;
+  banRate?: number;
+  tier?: string;
+  averages?: ChampionAverageStats | null;
   matchups: MatchupData[];
   itemBuilds: ItemBuildData[];
   startItemBuilds: StartItemBuildData[];

--- a/src/features/champion-stats-filter/index.ts
+++ b/src/features/champion-stats-filter/index.ts
@@ -1,1 +1,3 @@
 export { default as ChampionStatsFilters } from "./ui/ChampionStatsFilters";
+export { TIER_OPTIONS, getTierLabel, getNextLowerTier } from "./lib/tiers";
+export type { TierValue } from "./lib/tiers";

--- a/src/features/champion-stats-filter/lib/tiers.ts
+++ b/src/features/champion-stats-filter/lib/tiers.ts
@@ -1,0 +1,34 @@
+export const TIER_OPTIONS = [
+  { value: "CHALLENGER", label: "챌린저" },
+  { value: "GRANDMASTER", label: "그랜드마스터" },
+  { value: "GRANDMASTER+", label: "그랜드마스터+" },
+  { value: "MASTER", label: "마스터" },
+  { value: "MASTER+", label: "마스터+" },
+  { value: "DIAMOND", label: "다이아몬드" },
+  { value: "DIAMOND+", label: "다이아몬드+" },
+  { value: "EMERALD", label: "에메랄드" },
+  { value: "EMERALD+", label: "에메랄드+" },
+  { value: "PLATINUM", label: "플래티넘" },
+  { value: "PLATINUM+", label: "플래티넘+" },
+  { value: "GOLD", label: "골드" },
+  { value: "GOLD+", label: "골드+" },
+  { value: "SILVER", label: "실버" },
+  { value: "SILVER+", label: "실버+" },
+  { value: "BRONZE", label: "브론즈" },
+  { value: "BRONZE+", label: "브론즈+" },
+  { value: "IRON", label: "아이언" },
+  { value: "IRON+", label: "아이언+" },
+] as const;
+
+export type TierValue = (typeof TIER_OPTIONS)[number]["value"];
+
+export function getTierLabel(value: string): string {
+  return TIER_OPTIONS.find((o) => o.value === value)?.label ?? value;
+}
+
+export function getNextLowerTier(current: string): { value: string; label: string } | null {
+  const idx = TIER_OPTIONS.findIndex((o) => o.value === current);
+  if (idx < 0 || idx >= TIER_OPTIONS.length - 1) return null;
+  const next = TIER_OPTIONS[idx + 1];
+  return { value: next.value, label: next.label };
+}

--- a/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
+++ b/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
@@ -52,13 +52,13 @@ export default function ChampionStatsFilters({
   }, [handleClickOutside]);
 
   return (
-    <div className="flex items-center justify-center gap-2 flex-wrap">
+    <div className="grid grid-cols-3 gap-2 sm:flex sm:items-center sm:justify-center sm:flex-wrap">
       {/* 티어 */}
-      <div ref={tierRef} className="relative">
+      <div ref={tierRef} className="relative w-full sm:w-auto">
         <button
           type="button"
           onClick={() => setTierOpen((v) => !v)}
-          className="bg-surface-4 hover:bg-surface-8 border border-divider rounded-lg px-3 py-1.5 pr-8 text-sm font-medium text-on-surface cursor-pointer focus:outline-none min-w-[140px] text-left"
+          className="w-full sm:min-w-[140px] bg-surface-4 hover:bg-surface-8 border border-divider rounded-lg px-3 py-1.5 pr-8 text-sm font-medium text-on-surface cursor-pointer focus:outline-none text-left"
           aria-haspopup="listbox"
           aria-expanded={tierOpen}
         >
@@ -99,11 +99,11 @@ export default function ChampionStatsFilters({
 
       {/* 패치 */}
       {latestPatches.length > 0 && (
-        <div ref={patchRef} className="relative">
+        <div ref={patchRef} className="relative w-full sm:w-auto">
           <button
             type="button"
             onClick={() => setPatchOpen((v) => !v)}
-            className="bg-surface-4 hover:bg-surface-8 border border-divider rounded-lg px-3 py-1.5 pr-8 text-sm font-medium text-on-surface cursor-pointer focus:outline-none min-w-[80px] text-left"
+            className="w-full sm:min-w-[80px] bg-surface-4 hover:bg-surface-8 border border-divider rounded-lg px-3 py-1.5 pr-8 text-sm font-medium text-on-surface cursor-pointer focus:outline-none text-left"
             aria-haspopup="listbox"
             aria-expanded={patchOpen}
           >
@@ -144,11 +144,11 @@ export default function ChampionStatsFilters({
       )}
 
       {/* 플랫폼 */}
-      <div ref={platformRef} className="relative">
+      <div ref={platformRef} className="relative w-full sm:w-auto">
         <button
           type="button"
           onClick={() => setPlatformOpen((v) => !v)}
-          className="bg-surface-4 hover:bg-surface-8 border border-divider rounded-lg px-3 py-1.5 pr-8 text-sm font-medium text-on-surface cursor-pointer focus:outline-none min-w-[80px] text-left"
+          className="w-full sm:min-w-[80px] bg-surface-4 hover:bg-surface-8 border border-divider rounded-lg px-3 py-1.5 pr-8 text-sm font-medium text-on-surface cursor-pointer focus:outline-none text-left"
           aria-haspopup="listbox"
           aria-expanded={platformOpen}
         >

--- a/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
+++ b/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
@@ -4,29 +4,7 @@ import { AVAILABLE_REGIONS } from "@/features/region-select";
 import { useSeasonStore } from "@/entities/season";
 import { ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-
-// CHALLENGER+ 는 BE INVALID_TIER_FILTER이므로 의도적으로 제외
-const TIER_OPTIONS = [
-  { value: "CHALLENGER", label: "챌린저" },
-  { value: "GRANDMASTER", label: "그랜드마스터" },
-  { value: "GRANDMASTER+", label: "그랜드마스터+" },
-  { value: "MASTER", label: "마스터" },
-  { value: "MASTER+", label: "마스터+" },
-  { value: "DIAMOND", label: "다이아몬드" },
-  { value: "DIAMOND+", label: "다이아몬드+" },
-  { value: "EMERALD", label: "에메랄드" },
-  { value: "EMERALD+", label: "에메랄드+" },
-  { value: "PLATINUM", label: "플래티넘" },
-  { value: "PLATINUM+", label: "플래티넘+" },
-  { value: "GOLD", label: "골드" },
-  { value: "GOLD+", label: "골드+" },
-  { value: "SILVER", label: "실버" },
-  { value: "SILVER+", label: "실버+" },
-  { value: "BRONZE", label: "브론즈" },
-  { value: "BRONZE+", label: "브론즈+" },
-  { value: "IRON", label: "아이언" },
-  { value: "IRON+", label: "아이언+" },
-] as const;
+import { TIER_OPTIONS } from "../lib/tiers";
 
 interface ChampionStatsFiltersProps {
   selectedTier: string;

--- a/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
+++ b/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
@@ -19,6 +19,7 @@ import {
 import { useSeasonStore } from "@/entities/season";
 import { ChampionStatsFilters } from "@/features/champion-stats-filter";
 import { useMemo, useState } from "react";
+import { ErrorState, EmptyState, SkeletonStats } from "./ChampionStatsStates";
 
 interface ChampionStatsDetailPageClientProps {
   championId: string;
@@ -57,7 +58,7 @@ export default function ChampionStatsDetailPageClient({
     );
   }, [activePatch, selectedTier, selectedPlatform, initialActivePatch, initialTier, initialPlatformId, initialStatsData]);
 
-  const { data, isLoading, isError } = useChampionStats(
+  const { data, isLoading, isError, errorUpdatedAt, refetch } = useChampionStats(
     championKey,
     activePatch,
     selectedTier,
@@ -107,13 +108,9 @@ export default function ChampionStatsDetailPageClient({
           />
 
           {isLoading ? (
-            <div className="flex items-center justify-center py-20">
-              <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-            </div>
+            <SkeletonStats />
           ) : isError ? (
-            <div className="text-center py-20 text-loss">
-              통계 데이터를 불러오는 중 오류가 발생했습니다.
-            </div>
+            <ErrorState errorUpdatedAt={errorUpdatedAt} onRetry={() => refetch()} />
           ) : currentPositionStats ? (
             <>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -134,9 +131,13 @@ export default function ChampionStatsDetailPageClient({
               <MatchupStats data={currentPositionStats.matchups ?? []} />
             </>
           ) : activePatch ? (
-            <div className="text-center py-20 text-on-surface-medium">
-              해당 패치의 통계 데이터가 없습니다.
-            </div>
+            <EmptyState
+              selectedTier={selectedTier}
+              selectedPatch={activePatch}
+              patchVersions={latestPatches}
+              onTierChange={setSelectedTier}
+              onPatchChange={setSelectedPatch}
+            />
           ) : null}
         </div>
       </main>

--- a/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
+++ b/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
@@ -3,6 +3,7 @@
 import {
   BootBuildStats,
   ChampionOverview,
+  ChampionTimelineChart,
   ItemBuildStats,
   MatchupStats,
   PositionTabs,
@@ -13,6 +14,7 @@ import {
 import { Header, Navigation, Footer } from "@/widgets/layout";
 import {
   useChampionStats,
+  useChampionTimeline,
   type ApiPositionType,
   type ChampionStatsResponse,
 } from "@/entities/champion";
@@ -66,6 +68,13 @@ export default function ChampionStatsDetailPageClient({
     isInitialRequest ? { initialData: initialStatsData! } : undefined
   );
 
+  const { data: timelineData } = useChampionTimeline(
+    championKey,
+    activePatch,
+    selectedTier,
+    selectedPlatform
+  );
+
   // 사용 가능한 포지션 목록 추출
   const availablePositions = useMemo(() => {
     if (!data?.positions) return [];
@@ -85,6 +94,15 @@ export default function ChampionStatsDetailPageClient({
     if (!data?.positions || data.positions.length === 0 || !effectivePosition) return null;
     return data.positions.find((p) => p.teamPosition === effectivePosition) ?? data.positions[0];
   }, [data, effectivePosition]);
+
+  // 현재 포지션의 timeline frames
+  const currentTimelineFrames = useMemo(() => {
+    if (!timelineData?.positions || !effectivePosition) return [];
+    const match = timelineData.positions.find(
+      (p) => p.teamPosition === effectivePosition
+    );
+    return match?.frames ?? [];
+  }, [timelineData, effectivePosition]);
 
   return (
     <div className="min-h-screen bg-surface">
@@ -124,6 +142,7 @@ export default function ChampionStatsDetailPageClient({
                   championName={championId}
                 />
               </div>
+              <ChampionTimelineChart frames={currentTimelineFrames} />
               <ItemBuildStats data={currentPositionStats.itemBuilds} startItemBuilds={currentPositionStats.startItemBuilds} />
               <BootBuildStats data={currentPositionStats.bootBuilds} />
               <SpellStats data={currentPositionStats.spellStats} />

--- a/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
+++ b/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
@@ -90,7 +90,7 @@ export default function ChampionStatsDetailPageClient({
     <div className="min-h-screen bg-surface">
       <Header />
       <Navigation />
-      <main className="max-w-5xl mx-auto py-8">
+      <main className="max-w-6xl mx-auto px-4 py-8">
         <div className="space-y-6">
           <ChampionStatsFilters
             selectedTier={selectedTier}

--- a/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
+++ b/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
@@ -8,6 +8,7 @@ import {
   PositionTabs,
   RuneStats,
   SkillTreeStats,
+  SpellStats,
 } from "@/widgets/champion-stats-panel";
 import { Header, Navigation, Footer } from "@/widgets/layout";
 import {
@@ -128,6 +129,7 @@ export default function ChampionStatsDetailPageClient({
               </div>
               <ItemBuildStats data={currentPositionStats.itemBuilds} startItemBuilds={currentPositionStats.startItemBuilds} />
               <BootBuildStats data={currentPositionStats.bootBuilds} />
+              <SpellStats data={currentPositionStats.spellStats} />
               <RuneStats data={currentPositionStats.runeBuilds} />
               <MatchupStats data={currentPositionStats.matchups ?? []} />
             </>

--- a/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
+++ b/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
@@ -123,7 +123,7 @@ export default function ChampionStatsDetailPageClient({
                   championId={championId}
                 />
                 <SkillTreeStats
-                  data={currentPositionStats.skillBuilds.slice(0, 1)}
+                  data={currentPositionStats.skillBuilds}
                   championName={championId}
                 />
               </div>

--- a/src/views/champion-stats/ui/ChampionStatsStates.tsx
+++ b/src/views/champion-stats/ui/ChampionStatsStates.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { RotateCcw } from "lucide-react";
+import { getNextLowerTier, getTierLabel } from "@/features/champion-stats-filter";
+
+function formatTime(ts: number): string {
+  if (!ts) return "";
+  const d = new Date(ts);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}
+
+interface ErrorStateProps {
+  errorUpdatedAt: number;
+  onRetry: () => void;
+}
+
+export function ErrorState({ errorUpdatedAt, onRetry }: ErrorStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 gap-3">
+      <p className="text-loss text-sm">통계 데이터를 불러오는 중 오류가 발생했습니다.</p>
+      {errorUpdatedAt > 0 && (
+        <p className="text-on-surface-medium text-xs">
+          마지막 시도 {formatTime(errorUpdatedAt)}
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-surface-4 hover:bg-surface-8 border border-divider rounded-lg text-sm text-on-surface cursor-pointer focus:outline-none"
+      >
+        <RotateCcw className="w-3.5 h-3.5" />
+        재시도
+      </button>
+    </div>
+  );
+}
+
+interface EmptyStateProps {
+  selectedTier: string;
+  selectedPatch: string;
+  patchVersions: string[];
+  onTierChange: (tier: string) => void;
+  onPatchChange: (patch: string) => void;
+}
+
+export function EmptyState({
+  selectedTier,
+  selectedPatch,
+  patchVersions,
+  onTierChange,
+  onPatchChange,
+}: EmptyStateProps) {
+  const lowerTier = getNextLowerTier(selectedTier);
+  const activePatch = selectedPatch || patchVersions[0] || "";
+  const currentPatchIdx = patchVersions.indexOf(activePatch);
+  const previousPatch =
+    currentPatchIdx >= 0 && currentPatchIdx < patchVersions.length - 1
+      ? patchVersions[currentPatchIdx + 1]
+      : null;
+
+  return (
+    <div className="flex flex-col items-center justify-center py-20 gap-3">
+      <p className="text-on-surface-medium text-sm">
+        해당 조건의 통계 데이터가 없습니다.
+      </p>
+      <p className="text-on-surface-medium text-xs">
+        {getTierLabel(selectedTier)} · {activePatch || "최신"}
+      </p>
+      <div className="flex items-center gap-2 mt-1">
+        {lowerTier && (
+          <button
+            type="button"
+            onClick={() => onTierChange(lowerTier.value)}
+            className="px-3 py-1.5 bg-surface-4 hover:bg-surface-8 border border-divider rounded-lg text-sm text-on-surface cursor-pointer focus:outline-none"
+          >
+            {lowerTier.label} 보기
+          </button>
+        )}
+        {previousPatch && (
+          <button
+            type="button"
+            onClick={() => onPatchChange(previousPatch)}
+            className="px-3 py-1.5 bg-surface-4 hover:bg-surface-8 border border-divider rounded-lg text-sm text-on-surface cursor-pointer focus:outline-none"
+          >
+            이전 패치 ({previousPatch}) 보기
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonStats() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <SkeletonCard heightClass="h-[180px]" />
+        <SkeletonCard heightClass="h-[180px]" />
+      </div>
+      <SkeletonCard heightClass="h-[140px]" />
+      <SkeletonCard heightClass="h-[120px]" />
+    </div>
+  );
+}
+
+function SkeletonCard({ heightClass }: { heightClass: string }) {
+  return (
+    <div
+      className={`bg-surface-1 rounded-lg border border-divider ${heightClass}`}
+    />
+  );
+}

--- a/src/views/champion-stats/ui/ChampionStatsStates.tsx
+++ b/src/views/champion-stats/ui/ChampionStatsStates.tsx
@@ -20,7 +20,7 @@ interface ErrorStateProps {
 export function ErrorState({ errorUpdatedAt, onRetry }: ErrorStateProps) {
   return (
     <div className="flex flex-col items-center justify-center py-20 gap-3">
-      <p className="text-loss text-sm">통계 데이터를 불러오는 중 오류가 발생했습니다.</p>
+      <p className="text-loss text-sm">통계 데이터를 불러오지 못했습니다.</p>
       {errorUpdatedAt > 0 && (
         <p className="text-on-surface-medium text-xs">
           마지막 시도 {formatTime(errorUpdatedAt)}
@@ -64,7 +64,7 @@ export function EmptyState({
   return (
     <div className="flex flex-col items-center justify-center py-20 gap-3">
       <p className="text-on-surface-medium text-sm">
-        해당 조건의 통계 데이터가 없습니다.
+        선택한 조건의 통계가 없습니다.
       </p>
       <p className="text-on-surface-medium text-xs">
         {getTierLabel(selectedTier)} · {activePatch || "최신"}

--- a/src/widgets/champion-stats-panel/index.ts
+++ b/src/widgets/champion-stats-panel/index.ts
@@ -10,3 +10,4 @@ export { default as RuneStats } from "./ui/RuneStats";
 export { default as SkillTreeStats } from "./ui/SkillTreeStats";
 export { default as SpellStats } from "./ui/SpellStats";
 export { default as BuildConfidenceIndicator } from "./ui/BuildConfidenceIndicator";
+export { default as ChampionTimelineChart } from "./ui/ChampionTimelineChart";

--- a/src/widgets/champion-stats-panel/index.ts
+++ b/src/widgets/champion-stats-panel/index.ts
@@ -8,3 +8,4 @@ export { default as PositionTabsList } from "./ui/PositionTabsList";
 export { default as ChampionStatsTable } from "./ui/ChampionStatsTable";
 export { default as RuneStats } from "./ui/RuneStats";
 export { default as SkillTreeStats } from "./ui/SkillTreeStats";
+export { default as SpellStats } from "./ui/SpellStats";

--- a/src/widgets/champion-stats-panel/index.ts
+++ b/src/widgets/champion-stats-panel/index.ts
@@ -9,3 +9,4 @@ export { default as ChampionStatsTable } from "./ui/ChampionStatsTable";
 export { default as RuneStats } from "./ui/RuneStats";
 export { default as SkillTreeStats } from "./ui/SkillTreeStats";
 export { default as SpellStats } from "./ui/SpellStats";
+export { default as BuildConfidenceIndicator } from "./ui/BuildConfidenceIndicator";

--- a/src/widgets/champion-stats-panel/ui/BootBuildStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/BootBuildStats.tsx
@@ -6,6 +6,7 @@ import type { BootBuildData } from "@/entities/champion";
 import { getItemImageUrl } from "@/shared/lib/game";
 import Image from "next/image";
 import StatSectionHeader from "./StatSectionHeader";
+import BuildConfidenceIndicator from "./BuildConfidenceIndicator";
 
 const DEFAULT_VISIBLE = 2;
 
@@ -30,62 +31,54 @@ export default function BootBuildStats({ data }: BootBuildStatsProps) {
       />
       <div className="space-y-2">
         {visible.map((build, i) => (
-          <BuildRow
-            key={i}
-            bootId={build.bootId}
-            winRate={build.winRate}
-            games={build.games}
-            pickRate={build.pickRate}
-          />
+          <BuildRow key={i} build={build} />
         ))}
       </div>
     </div>
   );
 }
 
-function BuildRow({
-  bootId,
-  winRate,
-  games,
-  pickRate,
-}: {
-  bootId: number;
-  winRate: number;
-  games: number;
-  pickRate: number;
-}) {
-  const winRatePercent = winRate * 100;
+function BuildRow({ build }: { build: BootBuildData }) {
+  const winRatePercent = build.winRate * 100;
   return (
-    <div className="flex items-center gap-3 bg-surface rounded-lg px-3 py-2">
-      <GameTooltip type="item" id={bootId}>
-        <Image
-          src={getItemImageUrl(bootId)}
-          alt={`item-${bootId}`}
-          width={36}
-          height={36}
-          className="rounded border border-divider"
-          unoptimized
+    <div className="bg-surface rounded-lg px-3 py-2">
+      <div className="flex items-center gap-3">
+        <GameTooltip type="item" id={build.bootId}>
+          <Image
+            src={getItemImageUrl(build.bootId)}
+            alt={`item-${build.bootId}`}
+            width={36}
+            height={36}
+            className="rounded border border-divider"
+            unoptimized
+          />
+        </GameTooltip>
+        <div className="flex items-center gap-4 ml-auto text-xs">
+          <span>
+            <span className="text-on-surface-medium">승률 </span>
+            <span
+              className={`font-medium ${winRatePercent >= 50 ? "text-win" : "text-loss"}`}
+            >
+              {winRatePercent.toFixed(1)}%
+            </span>
+          </span>
+          <span>
+            <span className="text-on-surface-medium">픽률 </span>
+            <span className="font-medium text-on-surface">
+              {(build.pickRate * 100).toFixed(1)}%
+            </span>
+          </span>
+          <span className="text-on-surface-medium">
+            {build.games.toLocaleString()}게임
+          </span>
+        </div>
+      </div>
+      <div className="mt-1.5 pl-[48px]">
+        <BuildConfidenceIndicator
+          sampleSize={build.sampleSize}
+          totalSampleSize={build.totalSampleSize}
+          confidenceLowerBound={build.confidenceLowerBound}
         />
-      </GameTooltip>
-      <div className="flex items-center gap-4 ml-auto text-xs">
-        <span>
-          <span className="text-on-surface-medium">승률 </span>
-          <span
-            className={`font-medium ${winRatePercent >= 50 ? "text-win" : "text-loss"
-              }`}
-          >
-            {winRatePercent.toFixed(1)}%
-          </span>
-        </span>
-        <span>
-          <span className="text-on-surface-medium">픽률 </span>
-          <span className="font-medium text-on-surface">
-            {(pickRate * 100).toFixed(1)}%
-          </span>
-        </span>
-        <span className="text-on-surface-medium">
-          {games.toLocaleString()}게임
-        </span>
       </div>
     </div>
   );

--- a/src/widgets/champion-stats-panel/ui/BootBuildStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/BootBuildStats.tsx
@@ -1,22 +1,35 @@
 "use client";
 
+import { useState } from "react";
 import { GameTooltip } from "@/shared/ui/tooltip";
 import type { BootBuildData } from "@/entities/champion";
 import { getItemImageUrl } from "@/shared/lib/game";
 import Image from "next/image";
+import StatSectionHeader from "./StatSectionHeader";
+
+const DEFAULT_VISIBLE = 2;
 
 interface BootBuildStatsProps {
   data: BootBuildData[];
 }
 
 export default function BootBuildStats({ data }: BootBuildStatsProps) {
+  const [expanded, setExpanded] = useState(false);
   if (!data || data.length === 0) return null;
+
+  const visible = expanded ? data : data.slice(0, DEFAULT_VISIBLE);
 
   return (
     <div className="bg-surface-1 rounded-lg border border-divider p-0 md:p-5">
-      <h3 className="text-base font-bold text-on-surface p-2">신발 빌드</h3>
+      <StatSectionHeader
+        title="신발 빌드"
+        totalCount={data.length}
+        visibleCount={Math.min(DEFAULT_VISIBLE, data.length)}
+        expanded={expanded}
+        onToggle={() => setExpanded((v) => !v)}
+      />
       <div className="space-y-2">
-        {data.map((build, i) => (
+        {visible.map((build, i) => (
           <BuildRow
             key={i}
             bootId={build.bootId}

--- a/src/widgets/champion-stats-panel/ui/BuildConfidenceIndicator.tsx
+++ b/src/widgets/champion-stats-panel/ui/BuildConfidenceIndicator.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+interface BuildConfidenceIndicatorProps {
+  sampleSize?: number;
+  totalSampleSize?: number;
+  confidenceLowerBound?: number; // 0~1
+}
+
+type ConfidenceLevel = "low" | "mid" | "high" | "unknown";
+
+function levelOf(value: number | undefined): ConfidenceLevel {
+  if (value == null || value <= 0) return "unknown";
+  if (value < 0.45) return "low";
+  if (value < 0.55) return "mid";
+  return "high";
+}
+
+const LEVEL_LABEL: Record<ConfidenceLevel, string> = {
+  low: "낮음",
+  mid: "보통",
+  high: "높음",
+  unknown: "표본 부족",
+};
+
+const LEVEL_BAR: Record<ConfidenceLevel, string> = {
+  low: "bg-gray-500",
+  mid: "bg-amber-400",
+  high: "bg-emerald-500",
+  unknown: "bg-surface-4",
+};
+
+const LEVEL_TEXT: Record<ConfidenceLevel, string> = {
+  low: "text-on-surface-medium",
+  mid: "text-amber-400",
+  high: "text-emerald-500",
+  unknown: "text-on-surface-medium",
+};
+
+export default function BuildConfidenceIndicator({
+  sampleSize,
+  totalSampleSize,
+  confidenceLowerBound,
+}: BuildConfidenceIndicatorProps) {
+  const level = levelOf(confidenceLowerBound);
+  const sampleLabel =
+    sampleSize != null ? `표본 ${sampleSize.toLocaleString()}` : null;
+  const ratio =
+    totalSampleSize && totalSampleSize > 0 && sampleSize != null
+      ? (sampleSize / totalSampleSize) * 100
+      : null;
+
+  // 어떤 표시 데이터도 없으면 렌더 X
+  if (sampleLabel == null && confidenceLowerBound == null) return null;
+
+  return (
+    <div className="flex items-center gap-2 text-[11px] text-on-surface-medium">
+      {sampleLabel && (
+        <span>
+          {sampleLabel}
+          {ratio != null && (
+            <span className="ml-1 opacity-70">
+              · 전체의 {ratio.toFixed(1)}%
+            </span>
+          )}
+        </span>
+      )}
+      {confidenceLowerBound != null && (
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-10 h-1 bg-surface-4 rounded-full overflow-hidden">
+            <span
+              className={`block h-full ${LEVEL_BAR[level]}`}
+              style={{
+                width: `${Math.max(0, Math.min(1, confidenceLowerBound)) * 100}%`,
+              }}
+            />
+          </span>
+          <span className={`text-[10px] font-medium ${LEVEL_TEXT[level]}`}>
+            신뢰도 {LEVEL_LABEL[level]} ({(confidenceLowerBound * 100).toFixed(1)}%)
+          </span>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
@@ -28,6 +28,7 @@ export default function ChampionOverview({
 }: ChampionOverviewProps) {
   const championData = useGameDataStore((s) => s.championData);
   const champion = championData?.data[championId];
+  const championDisplayName = getChampionNameByEnglishName(championId);
 
   return (
     <div className="bg-surface-1 rounded-lg border border-divider p-3 sm:p-5">
@@ -35,7 +36,7 @@ export default function ChampionOverview({
         <GameTooltip type="champion" id={championId}>
           <Image
             src={getChampionImageUrl(championId)}
-            alt={championId}
+            alt={championDisplayName}
             width={64}
             height={64}
             className="rounded-lg shrink-0"
@@ -45,7 +46,7 @@ export default function ChampionOverview({
         <div className="flex flex-col gap-1.5 min-w-0 flex-1">
           <div className="flex items-center gap-2 flex-wrap">
             <h2 className="text-lg sm:text-xl font-bold text-on-surface truncate">
-              {getChampionNameByEnglishName(championId)}
+              {championDisplayName}
             </h2>
             <span
               className={`shrink-0 px-2 py-0.5 text-xs font-bold rounded ${getTierBadgeClass(tier)}`}

--- a/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
@@ -5,21 +5,13 @@ import type { ChampionPositionStats } from "@/entities/champion";
 import {
   getChampionImageUrl,
   getChampionNameByEnglishName,
+  getTierBadgeClass,
 } from "@/entities/champion";
 import { getChampionPassiveImageUrl } from "@/shared/lib/game";
 import { IMAGE_HOST } from "@/shared/config/image";
 import { GameTooltip } from "@/shared/ui/tooltip";
 import { useGameDataStore } from "@/shared/model/game-data";
 import Image from "next/image";
-
-const TIER_COLORS: Record<string, string> = {
-  "S+": "bg-red-500 text-white",
-  S: "bg-orange-500 text-white",
-  A: "bg-yellow-500 text-surface",
-  B: "bg-green-500 text-white",
-  C: "bg-blue-500 text-white",
-  D: "bg-gray-500 text-white",
-};
 
 const SKILL_KEYS = ["Q", "W", "E", "R"] as const;
 
@@ -68,9 +60,7 @@ export default function ChampionOverview({
         {/* 티어 */}
         <div className="self-start">
           <span
-            className={`px-2 py-0.5 text-xs font-bold rounded ${
-              TIER_COLORS[tier] || TIER_COLORS["D"]
-            }`}
+            className={`px-2 py-0.5 text-xs font-bold rounded ${getTierBadgeClass(tier)}`}
           >
             {tier}
           </span>

--- a/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
@@ -14,11 +14,38 @@ import { useGameDataStore } from "@/shared/model/game-data";
 import Image from "next/image";
 
 const SKILL_KEYS = ["Q", "W", "E", "R"] as const;
+const NA = "-";
 
 interface ChampionOverviewProps {
   data: ChampionPositionStats;
   tier: string;
   championId: string;
+}
+
+function formatRate(value: number | null | undefined): string {
+  if (value == null) return NA;
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatAvg(value: number | null | undefined, digits = 1): string {
+  if (value == null) return NA;
+  return value.toFixed(digits);
+}
+
+function formatGpm(value: number | null | undefined): string {
+  if (value == null) return NA;
+  return `${Math.round(value).toLocaleString()} G/min`;
+}
+
+function formatCs(
+  position: string,
+  laneCs: number | null | undefined,
+  jungleCs: number | null | undefined
+): string {
+  if (position === "JUNGLE") {
+    return jungleCs != null ? `${jungleCs.toFixed(1)} (jg)` : NA;
+  }
+  return laneCs != null ? `${laneCs.toFixed(1)} (lane)` : NA;
 }
 
 export default function ChampionOverview({
@@ -29,6 +56,16 @@ export default function ChampionOverview({
   const championData = useGameDataStore((s) => s.championData);
   const champion = championData?.data[championId];
   const championDisplayName = getChampionNameByEnglishName(championId);
+
+  // per-position tier 우선, fallback 으로 top-level tier
+  const displayedTier = data.tier ?? tier;
+  const averages = data.averages;
+  const hasAverages = !!averages;
+
+  const kdaLabel = hasAverages
+    ? `${formatAvg(averages?.avgKills)} / ${formatAvg(averages?.avgDeaths)} / ${formatAvg(averages?.avgAssists)}`
+    : "표본 부족";
+  const kdaScore = hasAverages ? `KDA ${formatAvg(averages?.kda, 2)}` : "";
 
   return (
     <div className="bg-surface-1 rounded-lg border border-divider p-3 sm:p-5">
@@ -49,10 +86,15 @@ export default function ChampionOverview({
               {championDisplayName}
             </h2>
             <span
-              className={`shrink-0 px-2 py-0.5 text-xs font-bold rounded ${getTierBadgeClass(tier)}`}
+              className={`shrink-0 px-2 py-0.5 text-xs font-bold rounded ${getTierBadgeClass(displayedTier)}`}
             >
-              {tier}
+              {displayedTier}
             </span>
+          </div>
+          <div className="text-xs text-on-surface-medium">
+            <span>픽률 {formatRate(data.pickRate)}</span>
+            <span className="mx-1.5">·</span>
+            <span>밴률 {formatRate(data.banRate)}</span>
           </div>
           <div className="flex items-center gap-1.5 flex-wrap">
             {champion?.passive && (
@@ -93,7 +135,7 @@ export default function ChampionOverview({
       <div className="grid grid-cols-3 gap-2 mt-3 pt-3 border-t border-divider/50">
         <StatCard
           label="승률"
-          value={`${(data.winRate * 100).toFixed(1)}%`}
+          value={formatRate(data.winRate)}
           valueClass={data.winRate >= 0.5 ? "text-win" : "text-loss"}
         />
         <StatCard
@@ -103,6 +145,22 @@ export default function ChampionOverview({
         <StatCard
           label="게임수"
           value={data.totalGames.toLocaleString()}
+        />
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 mt-2">
+        <StatCard
+          label="K / D / A"
+          value={kdaLabel}
+          subValue={kdaScore}
+        />
+        <StatCard
+          label="분당 골드"
+          value={formatGpm(averages?.avgGoldPerMinute)}
+        />
+        <StatCard
+          label="10분 CS"
+          value={formatCs(data.teamPosition, averages?.avgLaneCs10m, averages?.avgJungleCs10m)}
         />
       </div>
     </div>
@@ -144,16 +202,21 @@ function SkillIcon({
 function StatCard({
   label,
   value,
+  subValue,
   valueClass = "text-on-surface",
 }: {
   label: string;
   value: string;
+  subValue?: string;
   valueClass?: string;
 }) {
   return (
     <div className="flex flex-col items-center gap-0.5">
       <span className="text-on-surface-medium text-[11px]">{label}</span>
       <span className={`text-sm font-bold ${valueClass}`}>{value}</span>
+      {subValue && (
+        <span className="text-[10px] text-on-surface-medium">{subValue}</span>
+      )}
     </div>
   );
 }

--- a/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
@@ -30,82 +30,75 @@ export default function ChampionOverview({
   const champion = championData?.data[championId];
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-divider p-5">
-      <div className="grid grid-cols-[64px_1fr_auto] gap-x-4 gap-y-1">
-        {/* 챔피언 이미지 - row 1~2 */}
-        <div className="row-span-2 flex items-center">
-          <GameTooltip type="champion" id={championId}>
-            <Image
-              src={getChampionImageUrl(championId)}
-              alt={championId}
-              width={64}
-              height={64}
-              className="rounded-lg"
-              unoptimized
-            />
-          </GameTooltip>
+    <div className="bg-surface-1 rounded-lg border border-divider p-3 sm:p-5">
+      <div className="flex items-center gap-3 sm:gap-4">
+        <GameTooltip type="champion" id={championId}>
+          <Image
+            src={getChampionImageUrl(championId)}
+            alt={championId}
+            width={64}
+            height={64}
+            className="rounded-lg shrink-0"
+            unoptimized
+          />
+        </GameTooltip>
+        <div className="flex flex-col gap-1.5 min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h2 className="text-lg sm:text-xl font-bold text-on-surface truncate">
+              {getChampionNameByEnglishName(championId)}
+            </h2>
+            <span
+              className={`shrink-0 px-2 py-0.5 text-xs font-bold rounded ${getTierBadgeClass(tier)}`}
+            >
+              {tier}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {champion?.passive && (
+              <GameTooltip type="championPassive" id={championId}>
+                <div>
+                  <SkillIcon
+                    src={getChampionPassiveImageUrl(champion.passive.image.full)}
+                    label="P"
+                    alt={champion.passive.name}
+                  />
+                </div>
+              </GameTooltip>
+            )}
+            {SKILL_KEYS.map((key, index) => (
+              <GameTooltip
+                key={key}
+                type="championSpell"
+                id={`${championId}:${index}`}
+                disabled={!champion}
+              >
+                <div>
+                  <SkillIcon
+                    src={
+                      champion?.spells?.[index]?.image.full
+                        ? `${IMAGE_HOST}/spells/${champion.spells[index].image.full}`
+                        : `${IMAGE_HOST}/spells/${championId}${key}.png`
+                    }
+                    label={key}
+                    alt={champion?.spells?.[index]?.name ?? `${championId} ${key}`}
+                  />
+                </div>
+              </GameTooltip>
+            ))}
+          </div>
         </div>
+      </div>
 
-        {/* 챔피언명 */}
-        <h2 className="text-xl font-bold text-on-surface self-end">
-          {getChampionNameByEnglishName(championId)}
-        </h2>
-        {/* 승률 */}
+      <div className="grid grid-cols-3 gap-2 mt-3 pt-3 border-t border-divider/50">
         <StatCard
           label="승률"
           value={`${(data.winRate * 100).toFixed(1)}%`}
           valueClass={data.winRate >= 0.5 ? "text-win" : "text-loss"}
         />
-
-        {/* 티어 */}
-        <div className="self-start">
-          <span
-            className={`px-2 py-0.5 text-xs font-bold rounded ${getTierBadgeClass(tier)}`}
-          >
-            {tier}
-          </span>
-        </div>
-        {/* 승리 */}
         <StatCard
           label="승리"
           value={Math.round(data.totalGames * data.winRate).toLocaleString()}
         />
-
-        {/* 스킬 아이콘들 */}
-        <div className="col-span-2 flex items-center gap-1.5">
-          {champion?.passive && (
-            <GameTooltip type="championPassive" id={championId}>
-              <div>
-                <SkillIcon
-                  src={getChampionPassiveImageUrl(champion.passive.image.full)}
-                  label="P"
-                  alt={champion.passive.name}
-                />
-              </div>
-            </GameTooltip>
-          )}
-          {SKILL_KEYS.map((key, index) => (
-            <GameTooltip
-              key={key}
-              type="championSpell"
-              id={`${championId}:${index}`}
-              disabled={!champion}
-            >
-              <div>
-                <SkillIcon
-                  src={
-                    champion?.spells?.[index]?.image.full
-                      ? `${IMAGE_HOST}/spells/${champion.spells[index].image.full}`
-                      : `${IMAGE_HOST}/spells/${championId}${key}.png`
-                  }
-                  label={key}
-                  alt={champion?.spells?.[index]?.name ?? `${championId} ${key}`}
-                />
-              </div>
-            </GameTooltip>
-          ))}
-        </div>
-        {/* 게임수 */}
         <StatCard
           label="게임수"
           value={data.totalGames.toLocaleString()}
@@ -157,8 +150,8 @@ function StatCard({
   valueClass?: string;
 }) {
   return (
-    <div className="flex items-center gap-2 self-center justify-self-end">
-      <span className="text-on-surface-medium text-xs">{label}</span>
+    <div className="flex flex-col items-center gap-0.5">
+      <span className="text-on-surface-medium text-[11px]">{label}</span>
       <span className={`text-sm font-bold ${valueClass}`}>{value}</span>
     </div>
   );

--- a/src/widgets/champion-stats-panel/ui/ChampionStatsTable.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionStatsTable.tsx
@@ -1,20 +1,15 @@
 "use client";
 
 import type { PositionChampionEntry } from "@/entities/champion";
-import { getChampionImageUrl, getWinRateTextClass } from "@/entities/champion";
+import {
+  getChampionImageUrl,
+  getTierBadgeClass,
+  getWinRateTextClass,
+} from "@/entities/champion";
 import { useGameDataStore } from "@/shared/model/game-data";
 import Image from "next/image";
 import Link from "next/link";
 import { useMemo } from "react";
-
-const TIER_COLORS: Record<string, string> = {
-  "S+": "bg-red-500 text-white",
-  S: "bg-orange-500 text-white",
-  A: "bg-yellow-500 text-surface",
-  B: "bg-green-500 text-white",
-  C: "bg-blue-500 text-white",
-  D: "bg-gray-500 text-white",
-};
 
 interface ChampionStatsTableProps {
   champions: PositionChampionEntry[];
@@ -66,7 +61,7 @@ export default function ChampionStatsTable({
             const championId = info?.id ?? "";
             const winRatePercent = entry.winRate * 100;
 
-            const tierColor = TIER_COLORS[entry.tier] ?? TIER_COLORS["D"];
+            const tierColor = getTierBadgeClass(entry.tier);
 
             const content = (
               <>

--- a/src/widgets/champion-stats-panel/ui/ChampionTimelineChart.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionTimelineChart.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+} from "chart.js";
+import type { ChartData, ChartOptions } from "chart.js";
+import { Line } from "react-chartjs-2";
+import type { TimelineFrame } from "@/entities/champion";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip
+);
+
+type Metric = "gold" | "cs" | "xp";
+
+interface ChampionTimelineChartProps {
+  frames: TimelineFrame[];
+}
+
+const METRIC_LABEL: Record<Metric, string> = {
+  gold: "평균 골드",
+  cs: "평균 CS",
+  xp: "평균 경험치",
+};
+
+const METRIC_COLOR: Record<Metric, { line: string; fill: string }> = {
+  gold: { line: "rgba(255, 213, 79, 0.95)", fill: "rgba(255, 213, 79, 0.15)" },
+  cs: { line: "rgba(76, 175, 80, 0.95)", fill: "rgba(76, 175, 80, 0.15)" },
+  xp: { line: "rgba(102, 187, 255, 0.95)", fill: "rgba(102, 187, 255, 0.15)" },
+};
+
+function formatValue(metric: Metric, value: number): string {
+  if (metric === "cs") return value.toFixed(1);
+  return Math.round(value).toLocaleString();
+}
+
+function MiniChart({
+  metric,
+  frames,
+}: {
+  metric: Metric;
+  frames: TimelineFrame[];
+}) {
+  const labels = frames.map((f) => `${f.minute}분`);
+  const values = frames.map((f) =>
+    metric === "gold" ? f.avgGold : metric === "cs" ? f.avgCs : f.avgXp
+  );
+  const samples = frames.map((f) => f.sampleSize);
+  const colors = METRIC_COLOR[metric];
+
+  const data: ChartData<"line"> = {
+    labels,
+    datasets: [
+      {
+        data: values,
+        borderColor: colors.line,
+        backgroundColor: colors.fill,
+        borderWidth: 2,
+        pointRadius: 2.5,
+        pointHoverRadius: 5,
+        pointBackgroundColor: colors.line,
+        pointHoverBackgroundColor: "#fff",
+        pointHoverBorderColor: colors.line,
+        pointHoverBorderWidth: 2,
+        tension: 0.3,
+        fill: true,
+      },
+    ],
+  };
+
+  const options: ChartOptions<"line"> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: "index", intersect: false },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        backgroundColor: "rgba(30, 30, 30, 0.95)",
+        titleFont: { size: 11 },
+        bodyFont: { size: 11 },
+        padding: 8,
+        callbacks: {
+          label: (ctx) => {
+            const value = ctx.parsed.y ?? 0;
+            const sample = samples[ctx.dataIndex] ?? 0;
+            return [
+              `${METRIC_LABEL[metric]} ${formatValue(metric, value)}`,
+              `표본 ${sample.toLocaleString()}`,
+            ];
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        grid: { color: "rgba(255,255,255,0.06)" },
+        ticks: {
+          color: "rgba(255,255,255,0.4)",
+          font: { size: 10 },
+        },
+        border: { display: false },
+      },
+      y: {
+        grid: { color: "rgba(255,255,255,0.06)" },
+        ticks: {
+          color: "rgba(255,255,255,0.4)",
+          font: { size: 10 },
+          callback: (value) => {
+            const v = Number(value);
+            if (metric === "cs") return v.toFixed(0);
+            if (v >= 1000) return `${(v / 1000).toFixed(1)}k`;
+            return String(v);
+          },
+        },
+        border: { display: false },
+      },
+    },
+  };
+
+  return (
+    <div className="bg-surface rounded-lg p-3">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-xs font-medium text-on-surface">
+          {METRIC_LABEL[metric]}
+        </span>
+      </div>
+      <div className="h-32 sm:h-36">
+        <Line data={data} options={options} />
+      </div>
+    </div>
+  );
+}
+
+export default function ChampionTimelineChart({
+  frames,
+}: ChampionTimelineChartProps) {
+  const safeFrames = frames.filter((f) => f.sampleSize > 0);
+
+  if (safeFrames.length === 0) {
+    return (
+      <div className="bg-surface-1 rounded-lg border border-divider p-3 sm:p-5">
+        <h3 className="text-base font-bold text-on-surface p-2">
+          시간대별 평균
+        </h3>
+        <p className="text-center text-on-surface-medium text-sm py-8">
+          표본 부족으로 시간대별 데이터가 없습니다.
+        </p>
+      </div>
+    );
+  }
+
+  const minSample = Math.min(...safeFrames.map((f) => f.sampleSize));
+
+  return (
+    <div className="bg-surface-1 rounded-lg border border-divider p-3 sm:p-5">
+      <div className="flex items-end justify-between p-2">
+        <h3 className="text-base font-bold text-on-surface">시간대별 평균</h3>
+        <span className="text-[11px] text-on-surface-medium">
+          최소 표본 {minSample.toLocaleString()}
+        </span>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <MiniChart metric="gold" frames={safeFrames} />
+        <MiniChart metric="cs" frames={safeFrames} />
+        <MiniChart metric="xp" frames={safeFrames} />
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/champion-stats-panel/ui/ItemBuildStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/ItemBuildStats.tsx
@@ -1,9 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import { GameTooltip } from "@/shared/ui/tooltip";
 import type { ItemBuildData, StartItemBuildData } from "@/entities/champion";
 import { getItemImageUrl } from "@/shared/lib/game";
 import Image from "next/image";
+import StatSectionHeader from "./StatSectionHeader";
+
+const DEFAULT_VISIBLE = 2;
 
 interface ItemBuildStatsProps {
   data: ItemBuildData[];
@@ -11,7 +15,16 @@ interface ItemBuildStatsProps {
 }
 
 export default function ItemBuildStats({ data, startItemBuilds }: ItemBuildStatsProps) {
+  const [startExpanded, setStartExpanded] = useState(false);
+  const [coreExpanded, setCoreExpanded] = useState(false);
   if (data.length === 0 && (!startItemBuilds || startItemBuilds.length === 0)) return null;
+
+  const visibleStart = startItemBuilds
+    ? startExpanded
+      ? startItemBuilds
+      : startItemBuilds.slice(0, DEFAULT_VISIBLE)
+    : [];
+  const visibleCore = coreExpanded ? data : data.slice(0, DEFAULT_VISIBLE);
 
   return (
     <div className="bg-surface-1 rounded-lg border border-divider p-0 md:p-5">
@@ -20,9 +33,16 @@ export default function ItemBuildStats({ data, startItemBuilds }: ItemBuildStats
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {startItemBuilds && startItemBuilds.length > 0 && (
           <div>
-            <h4 className="text-sm font-medium text-on-surface-medium mb-2 p-2">시작 아이템</h4>
+            <StatSectionHeader
+              title="시작 아이템"
+              totalCount={startItemBuilds.length}
+              visibleCount={Math.min(DEFAULT_VISIBLE, startItemBuilds.length)}
+              expanded={startExpanded}
+              onToggle={() => setStartExpanded((v) => !v)}
+              size="sub"
+            />
             <div className="space-y-2">
-              {startItemBuilds.map((build, i) => (
+              {visibleStart.map((build, i) => (
                 <BuildRow
                   key={i}
                   itemIds={build.startItems}
@@ -37,9 +57,16 @@ export default function ItemBuildStats({ data, startItemBuilds }: ItemBuildStats
 
         {data.length > 0 && (
           <div>
-            <h4 className="text-sm font-medium text-on-surface-medium mb-2 p-2">코어 빌드</h4>
+            <StatSectionHeader
+              title="코어 빌드"
+              totalCount={data.length}
+              visibleCount={Math.min(DEFAULT_VISIBLE, data.length)}
+              expanded={coreExpanded}
+              onToggle={() => setCoreExpanded((v) => !v)}
+              size="sub"
+            />
             <div className="space-y-2">
-              {data.map((build, i) => (
+              {visibleCore.map((build, i) => (
                 <BuildRow
                   key={i}
                   itemIds={build.itemBuild}

--- a/src/widgets/champion-stats-panel/ui/ItemBuildStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/ItemBuildStats.tsx
@@ -6,6 +6,7 @@ import type { ItemBuildData, StartItemBuildData } from "@/entities/champion";
 import { getItemImageUrl } from "@/shared/lib/game";
 import Image from "next/image";
 import StatSectionHeader from "./StatSectionHeader";
+import BuildConfidenceIndicator from "./BuildConfidenceIndicator";
 
 const DEFAULT_VISIBLE = 2;
 
@@ -49,6 +50,9 @@ export default function ItemBuildStats({ data, startItemBuilds }: ItemBuildStats
                   winRate={build.winRate}
                   games={build.games}
                   pickRate={build.pickRate}
+                  sampleSize={build.sampleSize}
+                  totalSampleSize={build.totalSampleSize}
+                  confidenceLowerBound={build.confidenceLowerBound}
                 />
               ))}
             </div>
@@ -73,6 +77,9 @@ export default function ItemBuildStats({ data, startItemBuilds }: ItemBuildStats
                   winRate={build.winRate}
                   games={build.games}
                   pickRate={build.pickRate}
+                  sampleSize={build.sampleSize}
+                  totalSampleSize={build.totalSampleSize}
+                  confidenceLowerBound={build.confidenceLowerBound}
                 />
               ))}
             </div>
@@ -88,48 +95,62 @@ function BuildRow({
   winRate,
   games,
   pickRate,
+  sampleSize,
+  totalSampleSize,
+  confidenceLowerBound,
 }: {
   itemIds: number[];
   winRate: number;
   games: number;
   pickRate: number;
+  sampleSize?: number;
+  totalSampleSize?: number;
+  confidenceLowerBound?: number;
 }) {
   const winRatePercent = winRate * 100;
   return (
-    <div className="flex items-center gap-3 bg-surface rounded-lg px-3 py-2">
-      <div className="flex items-center gap-1">
-        {itemIds.map((itemId, j) => (
-          <GameTooltip key={j} type="item" id={itemId}>
-            <Image
-              src={getItemImageUrl(itemId)}
-              alt={`item-${itemId}`}
-              width={36}
-              height={36}
-              className="rounded border border-divider"
-              unoptimized
-            />
-          </GameTooltip>
-        ))}
+    <div className="bg-surface rounded-lg px-3 py-2">
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-1">
+          {itemIds.map((itemId, j) => (
+            <GameTooltip key={j} type="item" id={itemId}>
+              <Image
+                src={getItemImageUrl(itemId)}
+                alt={`item-${itemId}`}
+                width={36}
+                height={36}
+                className="rounded border border-divider"
+                unoptimized
+              />
+            </GameTooltip>
+          ))}
+        </div>
+        <div className="flex items-center gap-4 ml-auto text-xs">
+          <span>
+            <span className="text-on-surface-medium">승률 </span>
+            <span
+              className={`font-medium ${winRatePercent >= 50 ? "text-win" : "text-loss"}`}
+            >
+              {winRatePercent.toFixed(1)}%
+            </span>
+          </span>
+          <span>
+            <span className="text-on-surface-medium">픽률 </span>
+            <span className="font-medium text-on-surface">
+              {(pickRate * 100).toFixed(1)}%
+            </span>
+          </span>
+          <span className="text-on-surface-medium">
+            {games.toLocaleString()}게임
+          </span>
+        </div>
       </div>
-      <div className="flex items-center gap-4 ml-auto text-xs">
-        <span>
-          <span className="text-on-surface-medium">승률 </span>
-          <span
-            className={`font-medium ${winRatePercent >= 50 ? "text-win" : "text-loss"
-              }`}
-          >
-            {winRatePercent.toFixed(1)}%
-          </span>
-        </span>
-        <span>
-          <span className="text-on-surface-medium">픽률 </span>
-          <span className="font-medium text-on-surface">
-            {(pickRate * 100).toFixed(1)}%
-          </span>
-        </span>
-        <span className="text-on-surface-medium">
-          {games.toLocaleString()}게임
-        </span>
+      <div className="mt-1.5">
+        <BuildConfidenceIndicator
+          sampleSize={sampleSize}
+          totalSampleSize={totalSampleSize}
+          confidenceLowerBound={confidenceLowerBound}
+        />
       </div>
     </div>
   );

--- a/src/widgets/champion-stats-panel/ui/PositionTabs.tsx
+++ b/src/widgets/champion-stats-panel/ui/PositionTabs.tsx
@@ -20,7 +20,7 @@ export default function PositionTabs({
   const positions = availablePositions ?? ALL_POSITIONS;
 
   return (
-    <div className="flex border-b border-divider">
+    <div className="flex border-b border-divider overflow-x-auto scrollbar-thin">
       {positions.map((pos) => {
         const isActive = pos === selectedPosition;
         return (
@@ -28,7 +28,7 @@ export default function PositionTabs({
             key={pos}
             type="button"
             onClick={() => onSelectPosition(pos)}
-            className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium transition-colors border-b-2 cursor-pointer ${
+            className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium transition-colors border-b-2 cursor-pointer shrink-0 ${
               isActive
                 ? "text-on-surface border-primary"
                 : "text-on-surface-medium hover:text-on-surface border-transparent"

--- a/src/widgets/champion-stats-panel/ui/RuneStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/RuneStats.tsx
@@ -12,6 +12,7 @@ import { getStyleImageUrl } from "@/shared/lib/styles";
 import { useGameDataStore } from "@/shared/model/game-data";
 import Image from "next/image";
 import StatSectionHeader from "./StatSectionHeader";
+import BuildConfidenceIndicator from "./BuildConfidenceIndicator";
 
 const DEFAULT_VISIBLE = 2;
 
@@ -217,8 +218,7 @@ function RunePageRow({ build }: { build: RuneBuildData }) {
         <span>
           <span className="text-on-surface-medium">승률 </span>
           <span
-            className={`font-medium ${winRatePercent >= 50 ? "text-win" : "text-loss"
-              }`}
+            className={`font-medium ${winRatePercent >= 50 ? "text-win" : "text-loss"}`}
           >
             {winRatePercent.toFixed(1)}%
           </span>
@@ -232,6 +232,13 @@ function RunePageRow({ build }: { build: RuneBuildData }) {
         <span className="text-on-surface-medium">
           {build.games.toLocaleString()}게임
         </span>
+      </div>
+      <div className="flex justify-center mt-1.5">
+        <BuildConfidenceIndicator
+          sampleSize={build.sampleSize}
+          totalSampleSize={build.totalSampleSize}
+          confidenceLowerBound={build.confidenceLowerBound}
+        />
       </div>
     </div>
   );

--- a/src/widgets/champion-stats-panel/ui/RuneStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/RuneStats.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { GameTooltip } from "@/shared/ui/tooltip";
 import {
   RUNE_TREE_MAP,
@@ -10,19 +11,31 @@ import { getPerkImageUrl } from "@/shared/lib/game";
 import { getStyleImageUrl } from "@/shared/lib/styles";
 import { useGameDataStore } from "@/shared/model/game-data";
 import Image from "next/image";
+import StatSectionHeader from "./StatSectionHeader";
+
+const DEFAULT_VISIBLE = 2;
 
 interface RuneStatsProps {
   data: RuneBuildData[];
 }
 
 export default function RuneStats({ data }: RuneStatsProps) {
+  const [expanded, setExpanded] = useState(false);
   if (data.length === 0) return null;
+
+  const visible = expanded ? data : data.slice(0, DEFAULT_VISIBLE);
 
   return (
     <div className="bg-surface-1 rounded-lg border border-divider p-0 md:p-5">
-      <h3 className="text-base font-bold text-on-surface p-2">룬</h3>
+      <StatSectionHeader
+        title="룬"
+        totalCount={data.length}
+        visibleCount={Math.min(DEFAULT_VISIBLE, data.length)}
+        expanded={expanded}
+        onToggle={() => setExpanded((v) => !v)}
+      />
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {data.slice(0, 2).map((build, i) => (
+        {visible.map((build, i) => (
           <RunePageRow key={i} build={build} />
         ))}
       </div>

--- a/src/widgets/champion-stats-panel/ui/SkillTreeStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/SkillTreeStats.tsx
@@ -6,6 +6,9 @@ import type { SkillBuildData } from "@/entities/champion";
 import { useGameDataStore } from "@/shared/model/game-data";
 import { IMAGE_HOST } from "@/shared/config/image";
 import { GameTooltip } from "@/shared/ui/tooltip";
+import StatSectionHeader from "./StatSectionHeader";
+
+const DEFAULT_VISIBLE = 3;
 
 const SLOT_TO_SKILL: Record<string, string> = {
   "1": "Q", "2": "W", "3": "E", "4": "R",
@@ -64,16 +67,25 @@ export default function SkillTreeStats({
   data,
   championName,
 }: SkillTreeStatsProps) {
+  const [expanded, setExpanded] = useState(false);
   const championData = useGameDataStore((s) => s.championData);
   const champion = championData?.data[championName];
   if (data.length === 0) return null;
 
+  const visible = expanded ? data : data.slice(0, DEFAULT_VISIBLE);
+
   return (
     <div className="bg-surface-1 rounded-lg border border-divider p-0 md:p-5">
-      <h3 className="text-base font-bold text-on-surface p-2">스킬 트리</h3>
+      <StatSectionHeader
+        title="스킬 트리"
+        totalCount={data.length}
+        visibleCount={Math.min(DEFAULT_VISIBLE, data.length)}
+        expanded={expanded}
+        onToggle={() => setExpanded((v) => !v)}
+      />
 
       <div className="space-y-2">
-        {data.map((build, i) => {
+        {visible.map((build, i) => {
           const masterOrder = computeMasterOrder(build.skillBuild);
           const sequence = normalizeSkills(build.skillBuild);
           const winRatePercent = build.winRate * 100;

--- a/src/widgets/champion-stats-panel/ui/SkillTreeStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/SkillTreeStats.tsx
@@ -7,6 +7,7 @@ import { useGameDataStore } from "@/shared/model/game-data";
 import { IMAGE_HOST } from "@/shared/config/image";
 import { GameTooltip } from "@/shared/ui/tooltip";
 import StatSectionHeader from "./StatSectionHeader";
+import BuildConfidenceIndicator from "./BuildConfidenceIndicator";
 
 const DEFAULT_VISIBLE = 3;
 
@@ -135,6 +136,13 @@ export default function SkillTreeStats({
                     {skill}
                   </span>
                 ))}
+              </div>
+              <div className="mt-1.5">
+                <BuildConfidenceIndicator
+                  sampleSize={build.sampleSize}
+                  totalSampleSize={build.totalSampleSize}
+                  confidenceLowerBound={build.confidenceLowerBound}
+                />
               </div>
             </div>
           );

--- a/src/widgets/champion-stats-panel/ui/SpellStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/SpellStats.tsx
@@ -1,20 +1,33 @@
 "use client";
 
+import { useState } from "react";
 import type { SpellStatsData } from "@/entities/champion";
 import { SummonerSpellImage } from "@/shared/ui/game";
+import StatSectionHeader from "./StatSectionHeader";
+
+const DEFAULT_VISIBLE = 2;
 
 interface SpellStatsProps {
   data: SpellStatsData[];
 }
 
 export default function SpellStats({ data }: SpellStatsProps) {
+  const [expanded, setExpanded] = useState(false);
   if (!data || data.length === 0) return null;
+
+  const visible = expanded ? data : data.slice(0, DEFAULT_VISIBLE);
 
   return (
     <div className="bg-surface-1 rounded-lg border border-divider p-0 md:p-5">
-      <h3 className="text-base font-bold text-on-surface p-2">소환사 주문</h3>
+      <StatSectionHeader
+        title="소환사 주문"
+        totalCount={data.length}
+        visibleCount={Math.min(DEFAULT_VISIBLE, data.length)}
+        expanded={expanded}
+        onToggle={() => setExpanded((v) => !v)}
+      />
       <div className="space-y-2">
-        {data.map((build, i) => (
+        {visible.map((build, i) => (
           <BuildRow
             key={`${build.summoner1Id}-${build.summoner2Id}-${i}`}
             summoner1Id={build.summoner1Id}

--- a/src/widgets/champion-stats-panel/ui/SpellStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/SpellStats.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { SpellStatsData } from "@/entities/champion";
 import { SummonerSpellImage } from "@/shared/ui/game";
 import StatSectionHeader from "./StatSectionHeader";
+import BuildConfidenceIndicator from "./BuildConfidenceIndicator";
 
 const DEFAULT_VISIBLE = 2;
 
@@ -30,11 +31,7 @@ export default function SpellStats({ data }: SpellStatsProps) {
         {visible.map((build, i) => (
           <BuildRow
             key={`${build.summoner1Id}-${build.summoner2Id}-${i}`}
-            summoner1Id={build.summoner1Id}
-            summoner2Id={build.summoner2Id}
-            winRate={build.winRate}
-            games={build.games}
-            pickRate={build.pickRate}
+            build={build}
           />
         ))}
       </div>
@@ -42,46 +39,41 @@ export default function SpellStats({ data }: SpellStatsProps) {
   );
 }
 
-function BuildRow({
-  summoner1Id,
-  summoner2Id,
-  winRate,
-  games,
-  pickRate,
-}: {
-  summoner1Id: number;
-  summoner2Id: number;
-  winRate: number;
-  games: number;
-  pickRate: number;
-}) {
-  const winRatePercent = winRate * 100;
+function BuildRow({ build }: { build: SpellStatsData }) {
+  const winRatePercent = build.winRate * 100;
   return (
-    <div className="flex items-center gap-3 bg-surface rounded-lg px-3 py-2">
-      <div className="flex items-center gap-1.5">
-        <SummonerSpellImage spellId={summoner1Id} size="small" />
-        <SummonerSpellImage spellId={summoner2Id} size="small" />
+    <div className="bg-surface rounded-lg px-3 py-2">
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-1.5">
+          <SummonerSpellImage spellId={build.summoner1Id} size="small" />
+          <SummonerSpellImage spellId={build.summoner2Id} size="small" />
+        </div>
+        <div className="flex items-center gap-4 ml-auto text-xs">
+          <span>
+            <span className="text-on-surface-medium">승률 </span>
+            <span
+              className={`font-medium ${winRatePercent >= 50 ? "text-win" : "text-loss"}`}
+            >
+              {winRatePercent.toFixed(1)}%
+            </span>
+          </span>
+          <span>
+            <span className="text-on-surface-medium">픽률 </span>
+            <span className="font-medium text-on-surface">
+              {(build.pickRate * 100).toFixed(1)}%
+            </span>
+          </span>
+          <span className="text-on-surface-medium">
+            {build.games.toLocaleString()}게임
+          </span>
+        </div>
       </div>
-      <div className="flex items-center gap-4 ml-auto text-xs">
-        <span>
-          <span className="text-on-surface-medium">승률 </span>
-          <span
-            className={`font-medium ${
-              winRatePercent >= 50 ? "text-win" : "text-loss"
-            }`}
-          >
-            {winRatePercent.toFixed(1)}%
-          </span>
-        </span>
-        <span>
-          <span className="text-on-surface-medium">픽률 </span>
-          <span className="font-medium text-on-surface">
-            {(pickRate * 100).toFixed(1)}%
-          </span>
-        </span>
-        <span className="text-on-surface-medium">
-          {games.toLocaleString()}게임
-        </span>
+      <div className="mt-1.5">
+        <BuildConfidenceIndicator
+          sampleSize={build.sampleSize}
+          totalSampleSize={build.totalSampleSize}
+          confidenceLowerBound={build.confidenceLowerBound}
+        />
       </div>
     </div>
   );

--- a/src/widgets/champion-stats-panel/ui/SpellStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/SpellStats.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import type { SpellStatsData } from "@/entities/champion";
+import { SummonerSpellImage } from "@/shared/ui/game";
+
+interface SpellStatsProps {
+  data: SpellStatsData[];
+}
+
+export default function SpellStats({ data }: SpellStatsProps) {
+  if (!data || data.length === 0) return null;
+
+  return (
+    <div className="bg-surface-1 rounded-lg border border-divider p-0 md:p-5">
+      <h3 className="text-base font-bold text-on-surface p-2">소환사 주문</h3>
+      <div className="space-y-2">
+        {data.map((build, i) => (
+          <BuildRow
+            key={`${build.summoner1Id}-${build.summoner2Id}-${i}`}
+            summoner1Id={build.summoner1Id}
+            summoner2Id={build.summoner2Id}
+            winRate={build.winRate}
+            games={build.games}
+            pickRate={build.pickRate}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BuildRow({
+  summoner1Id,
+  summoner2Id,
+  winRate,
+  games,
+  pickRate,
+}: {
+  summoner1Id: number;
+  summoner2Id: number;
+  winRate: number;
+  games: number;
+  pickRate: number;
+}) {
+  const winRatePercent = winRate * 100;
+  return (
+    <div className="flex items-center gap-3 bg-surface rounded-lg px-3 py-2">
+      <div className="flex items-center gap-1.5">
+        <SummonerSpellImage spellId={summoner1Id} size="small" />
+        <SummonerSpellImage spellId={summoner2Id} size="small" />
+      </div>
+      <div className="flex items-center gap-4 ml-auto text-xs">
+        <span>
+          <span className="text-on-surface-medium">승률 </span>
+          <span
+            className={`font-medium ${
+              winRatePercent >= 50 ? "text-win" : "text-loss"
+            }`}
+          >
+            {winRatePercent.toFixed(1)}%
+          </span>
+        </span>
+        <span>
+          <span className="text-on-surface-medium">픽률 </span>
+          <span className="font-medium text-on-surface">
+            {(pickRate * 100).toFixed(1)}%
+          </span>
+        </span>
+        <span className="text-on-surface-medium">
+          {games.toLocaleString()}게임
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/champion-stats-panel/ui/StatSectionHeader.tsx
+++ b/src/widgets/champion-stats-panel/ui/StatSectionHeader.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+interface StatSectionHeaderProps {
+  title: string;
+  sortLabel?: string;
+  totalCount: number;
+  visibleCount: number;
+  expanded: boolean;
+  onToggle: () => void;
+  size?: "default" | "sub";
+}
+
+export default function StatSectionHeader({
+  title,
+  sortLabel = "픽률 순",
+  totalCount,
+  visibleCount,
+  expanded,
+  onToggle,
+  size = "default",
+}: StatSectionHeaderProps) {
+  const canExpand = totalCount > visibleCount;
+  const showButton = canExpand || expanded;
+  const titleClass =
+    size === "sub"
+      ? "text-sm font-medium text-on-surface-medium"
+      : "text-base font-bold text-on-surface";
+  const Tag = size === "sub" ? "h4" : "h3";
+
+  return (
+    <div className="flex items-end justify-between p-2">
+      <div className="flex items-baseline gap-2">
+        <Tag className={titleClass}>{title}</Tag>
+        {totalCount > 0 && (
+          <span className="text-[11px] text-on-surface-medium">
+            {sortLabel} 상위 {totalCount}개
+          </span>
+        )}
+      </div>
+      {showButton && (
+        <button
+          type="button"
+          onClick={onToggle}
+          className="text-xs text-primary hover:underline cursor-pointer"
+        >
+          {expanded ? "접기" : `더보기 (${totalCount - visibleCount})`}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

MP-9 "챔피언 분석 UI 전체적으로 수정" — `/champion-stats/[championId]` 상세 페이지를 op.gg/u.gg 풍 정보 밀도로 보강하면서 자체 미니멀 톤 유지.

### server-무관 ui 개선 (T1~T6)
- **T1 SpellStats 위젯 신설** — 소환사 주문(점화/순간이동/플래시 등) Top 빌드 표시. server 응답에 있었지만 UI 컴포넌트가 없던 가장 큰 갭.
- **T2 정렬 라벨 + 더보기 토글** — 빌드 위젯 모두에 "픽률 순" 부제 + `slice` 하드코딩 제거 후 더보기/접기. `StatSectionHeader` 공유 컴포넌트로 통일.
- **T3 빈/오류 상태 UX** — 스켈레톤 로딩, 오류 시 재시도 버튼 + 마지막 시도 시각, 빈 상태에 한 단계 낮은 티어 / 이전 패치 추천 버튼.
- **T4 티어 배지 시맨틱 정리** — `S+ gold / S amber / A emerald / B teal / C blue / D gray`. 기존 S+ 빨강(loss 톤) 어긋남 제거.
- **T5 반응형 정리** — filters `grid-cols-3`, position-tabs `overflow-x-auto`, `max-w-6xl`, ChampionOverview 모바일 안정 stack.
- **T6 a11y/카피** — 챔피언 이미지 `alt` 한글화 + 카피 톤 일관성.

### server 변경 hookup (T7~T9)
- **T7 ChampionOverview 메타 보강** — per-position 티어 배지 + 픽률/밴률 + KDA / 분당 골드 / 10분 CS(라이너 lane / 정글러 jg) stat row.
- **T8 빌드 신뢰도 표기** — 6개 빌드 위젯 모두에 `BuildConfidenceIndicator` (표본 수 + 전체 비율 + Wilson 95% 신뢰도 3단계 progress).
- **T9 시간대별 평균 곡선 차트** — Gold / CS / XP 3-up 미니 라인 차트 (5분 bucket: 10/15/20/25/30분). 기존 `chart.js + react-chartjs-2` 재사용 — 신규 의존성 0.

## Test plan

브라우저 실측 결과 (Playwright headless + `pnpm build/start`, dev:3001 + prod:3002):

| # | 항목 | 결과 |
|---|---|---|
| 1 | `/champion-stats/[championId]` 골든 패스 (Aatrox / Ahri 미드 CHALLENGER · 16.7) | PASS (조건부) — 5/8 위젯 렌더, 데이터 0 위젯은 의도된 null 반환 |
| 2 | server S2/M1/M2/L1 hookup 데이터 박힘 | PASS (정적+시각) — fallback("표본 부족"/"-") 정상 |
| 3 | 빈 상태 / 오류 / 재시도 trigger | PASS (Empty 자연) + SKIP (Error 인위 trigger 진입점 X) |
| 4 | 반응형 (360 / 768 / 1280) | PASS — 768 overflow는 `globals.css:185` design intent (회귀 아님) |
| 5 | T1~T6 시각 변경 | PASS (대부분) — T4 다양한 티어 비교 SKIP (백엔드 응답 단일) |
| 6 | 회귀 (`/`, `/champion-stats`, `/leaderboards`, `/community`, `/login`, `/patch-notes`) | PASS — 6/6 페이지 200 |

- [x] `npx tsc --noEmit` 통과
- [x] `pnpm lint` 통과 (사전 warning 만)
- [x] `pnpm build` 통과 (Turbopack 16.7s, 18 pages)
- [x] Playwright headless 스크린샷 — `/tmp/mp9-shots-v2/`, `/tmp/mp9-prod-shots/`

## 리뷰 포인트
- **chart.js 재사용**: 기존 `GoldFlowChart` 와 같은 라이브러리. 새 의존성 없이 SSR 호환 (`use client`) + client-only register.
- **빌드 신뢰도 3단계 색**: 회색/amber/emerald — 티어 시맨틱(T4)과 별개 톤. 표본 적은 빌드 사용자 안내 의도.
- **`ChampionListSidebar` (사이드바) 미사용**: 본 PR 범위 외. 챔피언 탐색 동선은 후속 이슈.

Closes MP-9

🤖 Generated by Padosol