### PR TITLE
fix: MP-18 next/image 호스트에 static.metapick.me 허용

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,11 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
+        hostname: "static.metapick.me",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
         hostname: "static.mmrtr.shop",
         pathname: "/**",
       },


### PR DESCRIPTION
## Summary
- 패치노트 페이지(`/patch-notes/[versionId]`)에서 next/image 가 `static.metapick.me` 호스트 미설정으로 런타임 에러를 던지던 문제 수정
- `next.config.ts` 의 `images.remotePatterns` 에 `static.metapick.me` (https, `/**`) 추가
- `NEXT_PUBLIC_IMAGE_HOST` 미설정 시 fallback 호스트(`shared/config/image.ts`)와 일치

## Reproduce
- `NEXT_PUBLIC_IMAGE_HOST` 미설정 상태에서 `pnpm dev` → `/patch-notes/<versionId>` 진입 시 PatchVisualSummary 위젯의 챔피언 썸네일에서 `Invalid src prop ... hostname "static.metapick.me" is not configured` 런타임 에러 발생.

## Why
- `src/widgets/patch-content/ui/PatchVisualSummary.tsx:117` 에서 챔피언 이미지 렌더 중 다음 에러 발생:
  > Invalid src prop (https://static.metapick.me/champion/Gragas.png) on next/image, hostname "static.metapick.me" is not configured under images in your next.config.js
- 다른 호스트(`static.mmrtr.shop`) 는 그대로 유지

## Coverage 점검
- `rg "metapick\.me" src/` 결과 `<Image>` 로 노출되는 호스트는 `static.metapick.me` 단일 (다른 CDN 변종 없음). 루트 도메인 `metapick.me` 는 sitemap·robots·Footer 텍스트 용도라 next/image 미경유.
- 같은 호스트를 쓰는 호출부: `widgets/{patch-content,match-history,ingame,match-detail}` — 한 번의 설정 추가로 모두 해결.

## Test plan
- [ ] `pnpm dev` 후 `/patch-notes/<versionId>` 진입해서 챔피언/아이템 썸네일 정상 렌더 확인
- [ ] 콘솔에 next/image 미설정 호스트 경고 없는지 확인
- [x] `pnpm lint` (0 errors)
- [x] `pnpm exec tsc --noEmit` 통과
- [x] CI Build / Lint / Slack Notification pass

Closes MP-18
Linear: https://linear.app/metapick/issue/MP-18/lol-ui-에러

🤖 Generated by Padosol