### PR TITLE
[MP-23] chore: AI-Ready 첫 audit baseline 추가 (총점 34/100)

### DIFF
--- a/.ai-ready-audit/2026-05-06/report.html
+++ b/.ai-ready-audit/2026-05-06/report.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>AI-Ready Audit · lol-ui</title>
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: #1e293b;
+      --panel-2: #334155;
+      --text: #f1f5f9;
+      --muted: #94a3b8;
+      --accent: #38bdf8;
+      --good: #22c55e;
+      --ok: #eab308;
+      --warn: #f97316;
+      --bad: #ef4444;
+      --border: #475569;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Pretendard', 'Noto Sans KR', sans-serif;
+      background: var(--bg); color: var(--text); line-height: 1.55;
+    }
+    .container { max-width: 1100px; margin: 0 auto; padding: 32px 24px 80px; }
+    h1, h2, h3 { margin: 0 0 12px; }
+    h1 { font-size: 28px; }
+    h2 { font-size: 22px; margin-top: 36px; border-bottom: 1px solid var(--border); padding-bottom: 8px; }
+    h3 { font-size: 18px; }
+    .muted { color: var(--muted); font-size: 13px; }
+    .header {
+      display: grid; grid-template-columns: 1fr auto; gap: 24px; align-items: end;
+      background: linear-gradient(135deg, var(--panel) 0%, var(--panel-2) 100%);
+      padding: 28px; border-radius: 16px; border: 1px solid var(--border);
+    }
+    .total-score {
+      font-size: 64px; font-weight: 700; line-height: 1; color: var(--accent);
+    }
+    .total-score small { font-size: 24px; color: var(--muted); }
+    .grade-badge {
+      display: inline-block; padding: 6px 14px; border-radius: 999px;
+      font-weight: 600; font-size: 14px; margin-top: 8px;
+    }
+    .grade-AI-Native { background: var(--good); color: #052e16; }
+    .grade-AI-Ready { background: var(--accent); color: #0c4a6e; }
+    .grade-AI-Assisted { background: var(--ok); color: #422006; }
+    .grade-AI-Fragile { background: var(--warn); color: #431407; }
+    .grade-AI-Hostile { background: var(--bad); color: #450a0a; }
+
+    .meta-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px;
+      margin-top: 24px;
+    }
+    .meta { background: var(--panel); padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); }
+    .meta .label { color: var(--muted); font-size: 12px; }
+    .meta .value { font-size: 18px; font-weight: 600; margin-top: 4px; }
+
+    .cat-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px;
+    }
+    .cat-card {
+      background: var(--panel); padding: 18px; border-radius: 12px; border: 1px solid var(--border);
+    }
+    .cat-card .cat-id { color: var(--muted); font-size: 12px; letter-spacing: 0.05em; }
+    .cat-card h3 { margin-top: 4px; }
+    .cat-card .scoreline {
+      display: flex; align-items: baseline; gap: 8px; margin-top: 8px;
+    }
+    .cat-card .score { font-size: 28px; font-weight: 700; }
+    .cat-card .max { color: var(--muted); }
+    .bar { height: 8px; background: var(--panel-2); border-radius: 999px; overflow: hidden; margin-top: 10px; }
+    .bar > div { height: 100%; transition: width .3s; }
+    .bar-good > div { background: var(--good); }
+    .bar-ok   > div { background: var(--ok); }
+    .bar-warn > div { background: var(--warn); }
+    .bar-bad  > div { background: var(--bad); }
+    .cat-card .desc { color: var(--muted); font-size: 13px; margin-top: 8px; }
+    .cat-card .reason { font-size: 13px; margin-top: 8px; padding: 8px 10px; background: rgba(56,189,248,.07); border-left: 2px solid var(--accent); border-radius: 4px; }
+
+    table {
+      width: 100%; border-collapse: collapse; margin-top: 12px;
+      background: var(--panel); border-radius: 12px; overflow: hidden;
+    }
+    th, td { text-align: left; padding: 12px 14px; border-bottom: 1px solid var(--border); }
+    th { background: var(--panel-2); font-size: 13px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+    tr:last-child td { border-bottom: none; }
+
+    .roi-rank {
+      display: inline-block; width: 24px; height: 24px; border-radius: 50%;
+      background: var(--accent); color: #0c4a6e; font-weight: 700; text-align: center; line-height: 24px;
+      font-size: 12px;
+    }
+    .effort-low    { color: var(--good); }
+    .effort-medium { color: var(--ok); }
+    .effort-high   { color: var(--warn); }
+
+    .warn-box {
+      background: rgba(249, 115, 22, .08); border: 1px solid var(--warn); padding: 14px;
+      border-radius: 10px; margin-top: 16px; font-size: 14px;
+    }
+    .ref-list { font-family: 'Menlo', 'Consolas', monospace; font-size: 12px; color: var(--muted); margin-top: 8px; }
+    .ref-list li { margin: 2px 0; }
+
+    footer { color: var(--muted); font-size: 12px; margin-top: 60px; text-align: center; }
+  </style>
+</head>
+<body>
+<div class="container">
+
+  <div class="header">
+    <div>
+      <div class="muted">AI-Ready Codebase Audit</div>
+      <h1>lol-ui</h1>
+      <div class="muted">/home/padosol/lol/.orch/mp-23/worktrees/ui · git ef2f9f5c · 2026-05-06T05:07:16.257441+00:00</div>
+      <div class="grade-badge grade-AI-Hostile">AI-Hostile</div>
+      <div class="muted" style="margin-top: 6px;">tribal knowledge 의존도가 높고 AI가 추측 기반으로 작업함</div>
+    </div>
+    <div style="text-align: right;">
+      <div class="total-score">34<small>/100</small></div>
+    </div>
+  </div>
+
+  <div class="meta-grid">
+    <div class="meta"><div class="label">Tracked files</div><div class="value">378</div></div>
+    <div class="meta"><div class="label">핵심 모듈</div><div class="value">3</div></div>
+    <div class="meta"><div class="label">CLAUDE.md / AGENTS.md</div><div class="value">1</div></div>
+    <div class="meta"><div class="label">Navigation Coverage</div><div class="value">0.0%</div></div>
+    <div class="meta"><div class="label">의심 broken refs</div><div class="value">10</div></div>
+  </div>
+
+  <h2>카테고리별 점수</h2>
+  <div class="cat-grid">
+    
+<div class="cat-card">
+  <div class="cat-id">A</div>
+  <h3>AI Navigation &amp; Coverage</h3>
+  <div class="scoreline"><span class="score">5</span><span class="max">/15</span></div>
+  <div class="bar bar-warn"><div style="width:33%"></div></div>
+  <div class="desc">AI가 전체 codebase/module/workflow를 빠르게 찾을 수 있는가</div>
+  <div class="reason">루트 CLAUDE.md(54줄)와 .github/WORKFLOWS.md만 존재. src/ 하위 6개 FSD 레이어(app/views/widgets/features/entities/shared)에 모듈별 context 0건. navigation_coverage_ratio=0.0.</div>
+  
+</div>
+
+
+<div class="cat-card">
+  <div class="cat-id">B</div>
+  <h3>Context Document Quality</h3>
+  <div class="scoreline"><span class="score">12</span><span class="max">/20</span></div>
+  <div class="bar bar-ok"><div style="width:60%"></div></div>
+  <div class="desc">context files가 'compass, not encyclopedia' 원칙을 따르는가</div>
+  
+  <table style="margin-top:12px; font-size:13px;"><tr><td><strong>B1</strong> Conciseness</td><td style="text-align:right">2/4</td></tr><tr><td><strong>B2</strong> Quick Commands</td><td style="text-align:right">4/4</td></tr><tr><td><strong>B3</strong> Key Files</td><td style="text-align:right">2/4</td></tr><tr><td><strong>B4</strong> Non-Obvious Patterns</td><td style="text-align:right">4/4</td></tr><tr><td><strong>B5</strong> See Also / Cross References</td><td style="text-align:right">0/4</td></tr></table>
+</div>
+
+
+<div class="cat-card">
+  <div class="cat-id">C</div>
+  <h3>Tribal Knowledge Externalization</h3>
+  <div class="scoreline"><span class="score">5</span><span class="max">/20</span></div>
+  <div class="bar bar-bad"><div style="width:25%"></div></div>
+  <div class="desc">숨은 규칙, 실패 패턴, human-only knowledge가 구조화되었는가</div>
+  <div class="reason">루트 CLAUDE.md 1개에 일부 gotcha(FSD 의존 방향, dual API, React Query TTL, GameDataLoader 타이밍)가 흩어져 있는 수준. five_question_module_coverage_pct 5개 모두 0.0 — 모듈별 5질문(소유, 수정 패턴, 실패 패턴, 의존, tribal)이 어떤 모듈에서도 답되지 않음. checklist/playbook/ADR 부재.</div>
+  
+</div>
+
+
+<div class="cat-card">
+  <div class="cat-id">D</div>
+  <h3>Cross-Module Dependency &amp; Data Flow Mapping</h3>
+  <div class="scoreline"><span class="score">5</span><span class="max">/15</span></div>
+  <div class="bar bar-warn"><div style="width:33%"></div></div>
+  <div class="desc">변경 영향 범위를 AI가 추적할 수 있는가</div>
+  <div class="reason">has_architecture_doc=false, has_dependency_map=false, 다이어그램 0건. 다만 루트 CLAUDE.md에 'app → views → widgets → features → entities → shared' FSD 의존 방향 텍스트 화살표 + Component → React Query → API 데이터 흐름 텍스트 다이어그램 존재 — 'note 존재' 수준.</div>
+  
+</div>
+
+
+<div class="cat-card">
+  <div class="cat-id">E</div>
+  <h3>Verification &amp; Quality Gates</h3>
+  <div class="scoreline"><span class="score">7</span><span class="max">/15</span></div>
+  <div class="bar bar-warn"><div style="width:47%"></div></div>
+  <div class="desc">AI-generated context와 code changes를 검증하는 체계가 있는가</div>
+  
+  <table style="margin-top:12px; font-size:13px;"><tr><td><strong>E1</strong> Reference Accuracy</td><td style="text-align:right">2/5</td></tr><tr><td><strong>E2</strong> Independent Critic Review</td><td style="text-align:right">1/4</td></tr><tr><td><strong>E3</strong> Task Validation</td><td style="text-align:right">3/4</td></tr><tr><td><strong>E4</strong> Prompt/Workflow Tests</td><td style="text-align:right">1/2</td></tr></table>
+</div>
+
+
+<div class="cat-card">
+  <div class="cat-id">F</div>
+  <h3>Freshness &amp; Self-Maintenance</h3>
+  <div class="scoreline"><span class="score">0</span><span class="max">/10</span></div>
+  <div class="bar bar-bad"><div style="width:0%"></div></div>
+  <div class="desc">context가 stale해지지 않도록 자동 유지되는가. stale context는 없는 context보다 위험.</div>
+  <div class="reason">doc freshness/link check CI 없음. dependabot.yml은 있으나 코드 의존성용. CLAUDE.md/README.md owner 명시 없음, stale 검출 메커니즘 부재. README.md의 docs/* 5건이 누락이지만 자동 검출 못 함이 그 증거.</div>
+  
+</div>
+
+
+<div class="cat-card">
+  <div class="cat-id">G</div>
+  <h3>Agent Performance Outcomes</h3>
+  <div class="scoreline"><span class="score">0</span><span class="max">/5</span></div>
+  <div class="bar bar-bad"><div style="width:0%"></div></div>
+  <div class="desc">실제 AI task 성공률/효율 개선이 측정되는가</div>
+  <div class="reason">AI task pass rate, tool calls, token usage, before/after 비교 등 어떤 agent performance metric도 측정·기록 없음. metrics dashboard 부재.</div>
+  
+</div>
+
+  </div>
+
+  <h2>ROI 우선순위 액션 리스트</h2>
+  <p class="muted">놓친 점수 / 추정 노력으로 정렬. 위에서부터 처리하면 점수 대비 효과가 큰 순서로 개선됩니다.</p>
+  <table>
+    <thead>
+      <tr>
+        <th>#</th><th>항목</th><th>현재</th><th>최대</th><th>놓친 점수</th><th>추정 노력</th><th>권장 액션</th>
+      </tr>
+    </thead>
+    <tbody>
+      
+<tr>
+  <td><span class="roi-rank">1</span></td>
+  <td>B5 · See Also / Cross References</td>
+  <td>0</td>
+  <td>4</td>
+  <td><strong>+4</strong></td>
+  <td class="effort-low">low</td>
+  <td>관련 module/context file/dependency map으로 연결</td>
+</tr>
+
+
+<tr>
+  <td><span class="roi-rank">2</span></td>
+  <td>A · AI Navigation &amp; Coverage</td>
+  <td>5</td>
+  <td>15</td>
+  <td><strong>+10</strong></td>
+  <td class="effort-medium">medium</td>
+  <td>FSD 레이어별 CLAUDE.md (entry point, 책임, 의존 방향) 추가 — 우선 features/, entities/, widgets/ 부터.</td>
+</tr>
+
+
+<tr>
+  <td><span class="roi-rank">3</span></td>
+  <td>F · Freshness &amp; Self-Maintenance</td>
+  <td>0</td>
+  <td>10</td>
+  <td><strong>+10</strong></td>
+  <td class="effort-medium">medium</td>
+  <td>lychee 또는 markdown-link-check를 PR 워크플로우에 추가, audit-codebase 자체를 주간 cron으로 등록.</td>
+</tr>
+
+
+<tr>
+  <td><span class="roi-rank">4</span></td>
+  <td>B1 · Conciseness</td>
+  <td>2</td>
+  <td>4</td>
+  <td><strong>+2</strong></td>
+  <td class="effort-low">low</td>
+  <td>25-35 lines 또는 약 1,000 tokens 내외</td>
+</tr>
+
+
+<tr>
+  <td><span class="roi-rank">5</span></td>
+  <td>B3 · Key Files</td>
+  <td>2</td>
+  <td>4</td>
+  <td><strong>+2</strong></td>
+  <td class="effort-low">low</td>
+  <td>실제 수정에 필요한 3-5개 핵심 파일 제시</td>
+</tr>
+
+
+<tr>
+  <td><span class="roi-rank">6</span></td>
+  <td>C · Tribal Knowledge Externalization</td>
+  <td>5</td>
+  <td>20</td>
+  <td><strong>+15</strong></td>
+  <td class="effort-high">high</td>
+  <td>features/, entities/ 핵심 모듈에 5질문 템플릿 기반 CLAUDE.md 작성. 매치 히스토리·소환사 검색·챔피언 통계 도메인부터.</td>
+</tr>
+
+
+<tr>
+  <td><span class="roi-rank">7</span></td>
+  <td>D · Cross-Module Dependency &amp; Data Flow Mapping</td>
+  <td>5</td>
+  <td>15</td>
+  <td><strong>+10</strong></td>
+  <td class="effort-high">high</td>
+  <td>ARCHITECTURE.md 신설: FSD 레이어 책임, 모듈 간 import 그래프(또는 mermaid), SSR vs CSR 라우트 매핑.</td>
+</tr>
+
+
+<tr>
+  <td><span class="roi-rank">8</span></td>
+  <td>E1 · Reference Accuracy</td>
+  <td>2</td>
+  <td>5</td>
+  <td><strong>+3</strong></td>
+  <td class="effort-medium">medium</td>
+  <td>file path, API, command hallucination 0건</td>
+</tr>
+
+
+<tr>
+  <td><span class="roi-rank">9</span></td>
+  <td>E3 · Task Validation</td>
+  <td>3</td>
+  <td>4</td>
+  <td><strong>+1</strong></td>
+  <td class="effort-low">low</td>
+  <td>build/test/lint/typecheck/e2e 등 변경 유형별 검증 명령 제공</td>
+</tr>
+
+
+<tr>
+  <td><span class="roi-rank">10</span></td>
+  <td>G · Agent Performance Outcomes</td>
+  <td>0</td>
+  <td>5</td>
+  <td><strong>+5</strong></td>
+  <td class="effort-high">high</td>
+  <td>정성적으로 '도움 된다' 수준</td>
+</tr>
+
+
+<tr>
+  <td><span class="roi-rank">11</span></td>
+  <td>E2 · Independent Critic Review</td>
+  <td>1</td>
+  <td>4</td>
+  <td><strong>+3</strong></td>
+  <td class="effort-high">high</td>
+  <td>최소 2-3 round의 독립 review 또는 checklist</td>
+</tr>
+
+
+<tr>
+  <td><span class="roi-rank">12</span></td>
+  <td>E4 · Prompt/Workflow Tests</td>
+  <td>1</td>
+  <td>2</td>
+  <td><strong>+1</strong></td>
+  <td class="effort-high">high</td>
+  <td>대표 AI task query를 실제로 테스트</td>
+</tr>
+
+    </tbody>
+  </table>
+
+  
+<h2>문서 내 의심 참조 (10건)</h2>
+<div class="warn-box">
+  context 문서에서 백틱/링크로 참조된 경로 중 audit이 실제로 찾지 못한 항목입니다.
+  실제로는 깊은 경로에 존재할 수 있으니 <strong>샘플링 검증 필수</strong>.
+  (E1. Reference Accuracy 점수에 영향)
+</div>
+<ul class="ref-list"><li><code>CLAUDE.md</code> → <code>app/GameDataLoader.tsx</code></li><li><code>CLAUDE.md</code> → <code>app/</code></li><li><code>CLAUDE.md</code> → <code>pages/</code></li><li><code>CLAUDE.md</code> → <code>shared/api/server-client.ts</code></li><li><code>CLAUDE.md</code> → <code>shared/api/client.ts</code></li><li><code>README.md</code> → <code>./docs/styling-guide.md</code></li><li><code>README.md</code> → <code>./docs/development-guide.md</code></li><li><code>README.md</code> → <code>./docs/libraries.md</code></li><li><code>README.md</code> → <code>./docs/component-guide.md</code></li><li><code>README.md</code> → <code>./docs/project-structure.md</code></li></ul>
+
+
+  <footer>
+    Generated by ai-ready-audit · rubric v1.0 · scorecard 입력: /home/padosol/lol/.orch/mp-23/worktrees/ui/.ai-ready-audit/2026-05-06/scorecard.json
+  </footer>
+
+</div>
+</body>
+</html>

--- a/.ai-ready-audit/2026-05-06/scorecard.json
+++ b/.ai-ready-audit/2026-05-06/scorecard.json
@@ -1,0 +1,79 @@
+{
+  "repo_name": "lol-ui",
+  "repo_path": "/home/padosol/lol/.orch/mp-23/worktrees/ui",
+  "git_head": "ef2f9f5cd04fa01e9e500c999947134a2887ae26",
+  "scanned_at": "2026-05-06T05:07:16.257441+00:00",
+  "tracked_files": 378,
+  "scores": {
+    "A": {
+      "score": 5,
+      "reason": "루트 CLAUDE.md(54줄)와 .github/WORKFLOWS.md만 존재. src/ 하위 6개 FSD 레이어(app/views/widgets/features/entities/shared)에 모듈별 context 0건. navigation_coverage_ratio=0.0.",
+      "action_hint": "FSD 레이어별 CLAUDE.md (entry point, 책임, 의존 방향) 추가 — 우선 features/, entities/, widgets/ 부터."
+    },
+    "B": {
+      "score": 12,
+      "items": {
+        "B1": {
+          "score": 2,
+          "reason": "CLAUDE.md 54줄 — 권장(25-35) 초과. 명령어/아키텍처/non-obvious/env 4섹션이 다 들어있어 1.5배 분량."
+        },
+        "B2": {
+          "score": 4,
+          "reason": "## Commands 섹션에 pnpm dev/build/lint/playwright 4개 copy-paste 가능 명령 정리. (signal은 헤더 패턴 매칭에서 놓쳤지만 본문에 존재)"
+        },
+        "B3": {
+          "score": 2,
+          "reason": "전용 Key Files 섹션은 없으나 Non-obvious Decisions 안에서 GameDataLoader.tsx, shared/api/client.ts, server-client.ts, globals.css 등 핵심 파일 4개 인용."
+        },
+        "B4": {
+          "score": 4,
+          "reason": "## Non-obvious Decisions 섹션이 우수: views/ 명명 이유, Dual API Client(브라우저/Docker 내부), SSR/CSR 분리 패턴, React Query TTL(5/2/10분), GameDataLoader 사전 로드, Material Design 테마 색상까지 6개 hidden rule 명시."
+        },
+        "B5": {
+          "score": 0,
+          "reason": "See Also / 관련 문서 / 의존 모듈 cross-link 섹션 없음. WORKFLOWS.md ↔ CLAUDE.md 간 링크도 부재."
+        }
+      }
+    },
+    "C": {
+      "score": 5,
+      "reason": "루트 CLAUDE.md 1개에 일부 gotcha(FSD 의존 방향, dual API, React Query TTL, GameDataLoader 타이밍)가 흩어져 있는 수준. five_question_module_coverage_pct 5개 모두 0.0 — 모듈별 5질문(소유, 수정 패턴, 실패 패턴, 의존, tribal)이 어떤 모듈에서도 답되지 않음. checklist/playbook/ADR 부재.",
+      "action_hint": "features/, entities/ 핵심 모듈에 5질문 템플릿 기반 CLAUDE.md 작성. 매치 히스토리·소환사 검색·챔피언 통계 도메인부터."
+    },
+    "D": {
+      "score": 5,
+      "reason": "has_architecture_doc=false, has_dependency_map=false, 다이어그램 0건. 다만 루트 CLAUDE.md에 'app → views → widgets → features → entities → shared' FSD 의존 방향 텍스트 화살표 + Component → React Query → API 데이터 흐름 텍스트 다이어그램 존재 — 'note 존재' 수준.",
+      "action_hint": "ARCHITECTURE.md 신설: FSD 레이어 책임, 모듈 간 import 그래프(또는 mermaid), SSR vs CSR 라우트 매핑."
+    },
+    "E": {
+      "score": 7,
+      "items": {
+        "E1": {
+          "score": 2,
+          "reason": "broken_path_refs_in_docs=10. 검증 결과 5건은 false positive(CLAUDE.md가 'app/GameDataLoader.tsx' 같은 src/ 상대경로 사용 — 실제 src/app/GameDataLoader.tsx 존재). 하지만 README.md의 docs/styling-guide.md, docs/development-guide.md, docs/libraries.md, docs/component-guide.md, docs/project-structure.md 5건은 실재 broken — docs/ 하위에 index.html과 patch/만 존재. WORKFLOWS.md도 claude-code-review.yml/claude.yml 참조하나 workflows/에 없음."
+        },
+        "E2": {
+          "score": 1,
+          "reason": "PR 템플릿(.github/PULL_REQUEST_TEMPLATE.md) 없음. 다만 WORKFLOWS.md에 Claude Code Review 워크플로우가 정의되어 있어 일부 자동 critic가 의도되어 있음(워크플로우 파일 자체는 누락 — broken)."
+        },
+        "E3": {
+          "score": 3,
+          "reason": "ci.yml에 lint + build 두 잡 분리 실행. CodeQL(security-and-quality), dependency-review, lighthouse CI까지 6개 워크플로우 운영. 다만 별도 typecheck/test 잡은 없음(build에 포함)."
+        },
+        "E4": {
+          "score": 1,
+          "reason": "대표 AI task에 대한 prompt suite·정형 평가 부재. 단, .github/workflows/lighthouse.yml로 PR마다 성능 회귀를 정량 측정하는 task validation은 있음 — 코드 품질 측정 측면에서 부분 점수."
+        }
+      }
+    },
+    "F": {
+      "score": 0,
+      "reason": "doc freshness/link check CI 없음. dependabot.yml은 있으나 코드 의존성용. CLAUDE.md/README.md owner 명시 없음, stale 검출 메커니즘 부재. README.md의 docs/* 5건이 누락이지만 자동 검출 못 함이 그 증거.",
+      "action_hint": "lychee 또는 markdown-link-check를 PR 워크플로우에 추가, audit-codebase 자체를 주간 cron으로 등록."
+    },
+    "G": {
+      "score": 0,
+      "reason": "AI task pass rate, tool calls, token usage, before/after 비교 등 어떤 agent performance metric도 측정·기록 없음. metrics dashboard 부재."
+    }
+  }
+}

--- a/.ai-ready-audit/2026-05-06/signals.json
+++ b/.ai-ready-audit/2026-05-06/signals.json
@@ -1,0 +1,162 @@
+{
+  "schema_version": "1.0",
+  "tool": "ai-ready-audit/audit.py",
+  "scanned_at": "2026-05-06T05:07:16.257441+00:00",
+  "repo_path": "/home/padosol/lol/.orch/mp-23/worktrees/ui",
+  "git_head": "ef2f9f5cd04fa01e9e500c999947134a2887ae26",
+  "totals": {
+    "tracked_files": 378
+  },
+  "signals": {
+    "core_modules_total": 3,
+    "core_modules_with_context": 0,
+    "core_modules_with_strong_context": 0,
+    "navigation_coverage_ratio": 0.0,
+    "claude_md_count": 1,
+    "agents_md_count": 0,
+    "claude_md_locations": [
+      "CLAUDE.md"
+    ],
+    "claude_md_line_distribution": [
+      54
+    ],
+    "context_files_total": 2,
+    "context_files_with_commands_section": 0,
+    "context_files_with_key_files_section": 0,
+    "context_files_with_gotcha_section": 1,
+    "context_files_with_xref_section": 0,
+    "modules_answering_q1_what_owned": 0,
+    "modules_answering_q2_modification_patterns": 0,
+    "modules_answering_q3_failure_patterns": 0,
+    "modules_answering_q4_dependencies": 0,
+    "modules_answering_q5_tribal_knowledge": 0,
+    "five_question_module_coverage_pct": [
+      0.0,
+      0.0,
+      0.0,
+      0.0,
+      0.0
+    ],
+    "has_architecture_doc": false,
+    "has_dependency_map": false,
+    "has_data_flow_diagram": false,
+    "has_any_diagram": false,
+    "arch_doc_paths": [],
+    "dep_doc_paths": [],
+    "github_workflow_count": 6,
+    "other_ci_files": [],
+    "has_lint_ci": true,
+    "has_test_ci": false,
+    "has_typecheck_ci": false,
+    "has_doc_ci": false,
+    "has_freshness_ci": false,
+    "broken_path_refs_in_docs": 10,
+    "broken_refs_sample": [
+      {
+        "doc": "CLAUDE.md",
+        "ref": "app/GameDataLoader.tsx"
+      },
+      {
+        "doc": "CLAUDE.md",
+        "ref": "app/"
+      },
+      {
+        "doc": "CLAUDE.md",
+        "ref": "pages/"
+      },
+      {
+        "doc": "CLAUDE.md",
+        "ref": "shared/api/server-client.ts"
+      },
+      {
+        "doc": "CLAUDE.md",
+        "ref": "shared/api/client.ts"
+      },
+      {
+        "doc": "README.md",
+        "ref": "./docs/styling-guide.md"
+      },
+      {
+        "doc": "README.md",
+        "ref": "./docs/development-guide.md"
+      },
+      {
+        "doc": "README.md",
+        "ref": "./docs/libraries.md"
+      },
+      {
+        "doc": "README.md",
+        "ref": "./docs/component-guide.md"
+      },
+      {
+        "doc": "README.md",
+        "ref": "./docs/project-structure.md"
+      }
+    ]
+  },
+  "modules": [
+    {
+      "path": "design",
+      "name": "design",
+      "file_count": 14,
+      "has_readme": false,
+      "has_claude_md": false,
+      "has_agents_md": false,
+      "context_paths": []
+    },
+    {
+      "path": "plans",
+      "name": "plans",
+      "file_count": 7,
+      "has_readme": false,
+      "has_claude_md": false,
+      "has_agents_md": false,
+      "context_paths": []
+    },
+    {
+      "path": "src",
+      "name": "src",
+      "file_count": 307,
+      "has_readme": false,
+      "has_claude_md": false,
+      "has_agents_md": false,
+      "context_paths": []
+    }
+  ],
+  "context_files": [
+    {
+      "path": "CLAUDE.md",
+      "lines": 54,
+      "bytes_": 2437,
+      "has_quick_commands": false,
+      "has_key_files": false,
+      "has_gotcha": true,
+      "has_see_also": false,
+      "five_question_hits": {
+        "q1_what_owned": false,
+        "q2_modification_patterns": false,
+        "q3_failure_patterns": false,
+        "q4_dependencies": true,
+        "q5_tribal_knowledge": true
+      },
+      "has_mermaid": false
+    },
+    {
+      "path": "README.md",
+      "lines": 79,
+      "bytes_": 1685,
+      "has_quick_commands": false,
+      "has_key_files": false,
+      "has_gotcha": false,
+      "has_see_also": false,
+      "five_question_hits": {
+        "q1_what_owned": false,
+        "q2_modification_patterns": false,
+        "q3_failure_patterns": false,
+        "q4_dependencies": true,
+        "q5_tribal_knowledge": false
+      },
+      "has_mermaid": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

audit-codebase 스킬로 lol-ui 첫 AI-Ready 점수 산정 (baseline, 비교 대상 없음).

산출물 3종을 `.ai-ready-audit/2026-05-06/` 에 추가:
- `signals.json` — audit.py mechanical signal (378 tracked files, 6 workflows, broken refs 10건 등)
- `scorecard.json` — 7개 카테고리(A~G) 한국어 reason 포함 점수표
- `report.html` — 한국어 대시보드 (총점, 카테고리 카드, ROI 우선순위 표, broken refs 경고)

## 총점 · 등급

**34 / 100 — AI-Hostile** (0~39)

> tribal knowledge 의존도가 높고 AI가 추측 기반으로 작업함

baseline 측정이며 향후 audit 과 비교 대상이 됨 (첫 audit, 비교 대상 없음).

## 카테고리별 점수

| 카테고리 | 점수 | 핵심 사유 |
|---|---|---|
| A · AI Navigation & Coverage | 5 / 15 | 루트 CLAUDE.md 1개만 존재. src/ 하위 6개 FSD 레이어(app/views/widgets/features/entities/shared) 모두 모듈별 context 0건 |
| B · Context Document Quality | 12 / 20 | B1=2(54줄, 권장 25-35 초과), B2=4(Commands 섹션 우수), B3=2(Key Files 전용 섹션 부재), B4=4(Non-obvious Decisions 섹션 매우 우수), B5=0(See Also/cross-link 없음) |
| C · Tribal Knowledge Externalization | 5 / 20 | five_question_module_coverage 5개 모두 0%. 일부 gotcha만 루트 CLAUDE.md에 산재 |
| D · Cross-Module Dependency & Data Flow | 5 / 15 | 형식적 ARCHITECTURE.md/dependency map 없음. CLAUDE.md에 FSD 텍스트 화살표 + 데이터 흐름 sketch 만 존재 |
| E · Verification & Quality Gates | 7 / 15 | E1=2(README.md docs/* 5건 실재 broken), E2=1(PR 템플릿 없음, Claude Code Review 워크플로우 broken 참조), E3=3(lint+build+CodeQL+lighthouse+dep-review CI 운영), E4=1(lighthouse 회귀 측정 부분 인정) |
| F · Freshness & Self-Maintenance | 0 / 10 | doc freshness/link check CI 부재. owner 명시 없음 |
| G · Agent Performance Outcomes | 0 / 5 | AI task 성능 지표 없음 (default 0) |

## ROI 우선순위 액션 (top 3)

`gap × 1/effort_weight` 내림차순.

1. **B5 · See Also / Cross References** — gap +4, effort low
   - CLAUDE.md ↔ WORKFLOWS.md, 루트 ↔ 모듈 context 간 cross-link 섹션 추가. 가장 적은 노력으로 4점.
2. **A · AI Navigation & Coverage** — gap +10, effort medium
   - FSD 레이어별 CLAUDE.md (entry point, 책임, 의존 방향) 추가. features/, entities/, widgets/ 부터 단계적으로.
3. **F · Freshness & Self-Maintenance** — gap +10, effort medium
   - lychee 또는 markdown-link-check를 PR 워크플로우에 추가. audit-codebase 자체를 주간 cron 으로 등록해 자동 스코어 추적.

## Test plan
- [ ] `report.html` 브라우저로 열어 시각화 확인 (점수 카드, ROI 표, broken refs 경고 박스)
- [ ] `scorecard.json` 의 각 카테고리 reason 이 한국어로 작성되었는지 확인
- [ ] `signals.json` 의 git_head 가 ef2f9f5 (현재 base) 와 일치하는지 확인

Closes MP-23

🤖 Generated by Padosol