### PR TITLE
docs: MP-28 lol-ui docs/ 5종 신규 작성 + README trim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,31 @@
-# LoL 전적 검색 서비스
+# LoL 전적 검색 서비스 (lol-ui)
 
-League of Legends 전적 검색 서비스를 위한 Next.js 기반 웹 애플리케이션입니다.
+League of Legends 전적 검색 서비스의 웹 프론트엔드.
+Next.js 16 (App Router) + Feature-Sliced Design.
 
-## 기술 스택
-
-- **Framework**: Next.js 16 (App Router)
-- **UI Library**: React 19
-- **Language**: TypeScript
-- **Styling**: Tailwind CSS v4
-- **State Management**: Zustand
-- **Data Fetching**: TanStack Query (React Query)
-- **Form Management**: React Hook Form + Zod
-- **Charts**: Chart.js + react-chartjs-2
-- **Icons**: Lucide React
-
-## 시작하기
-
-### 설치
+## 빠른 시작
 
 ```bash
-npm install
+pnpm install
+pnpm dev          # http://localhost:3000
 ```
 
-### 개발 서버 실행
-
-```bash
-npm run dev
-```
-
-브라우저에서 [http://localhost:3000](http://localhost:3000)을 열어 확인하세요.
-
-### 빌드
-
-```bash
-npm run build
-```
-
-### 프로덕션 실행
-
-```bash
-npm start
-```
-
-## 프로젝트 구조
-
-```
-src/
-├── app/              # Next.js App Router
-│   ├── layout.tsx   # 루트 레이아웃
-│   └── page.tsx     # 홈 페이지
-└── components/       # 재사용 가능한 컴포넌트
-    ├── Header.tsx
-    ├── Navigation.tsx
-    ├── DesktopAppSection.tsx
-    └── Footer.tsx
-```
-
-## 문서
-
-자세한 문서는 [`docs/`](./docs/) 폴더를 참조하세요:
-
-- [프로젝트 구조](./docs/project-structure.md)
-- [라이브러리 및 의존성](./docs/libraries.md)
-- [컴포넌트 작성 가이드](./docs/component-guide.md)
-- [스타일링 가이드](./docs/styling-guide.md)
-- [개발 가이드](./docs/development-guide.md)
+`.env.local` 키 / 빌드·lint·E2E 명령은 [`docs/development-guide.md`](./docs/development-guide.md).
 
 ## 주요 기능
 
 - 🔍 소환사 전적 검색
-- 📊 전적 데이터 시각화
+- 📊 매치 데이터 시각화
 - 🎮 게임 모드별 통계
 - 📈 챔피언 통계 및 빌드
+
+## 문서
+
+- [프로젝트 구조](./docs/project-structure.md) — FSD 레이어 / SSR vs CSR
+- [컴포넌트 작성 가이드](./docs/component-guide.md) — 어디에 둘지 결정 트리
+- [라이브러리 및 의존성](./docs/libraries.md) — Next.js / React Query / Zustand / Tailwind / …
+- [스타일링 가이드](./docs/styling-guide.md) — Tailwind v4 토큰 / 다크-라이트
+- [개발 가이드](./docs/development-guide.md) — 환경 변수 / 명령 / pre-commit
 
 ## 라이선스
 

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -1,0 +1,45 @@
+# 컴포넌트 작성 가이드
+
+새 컴포넌트를 만들 때 어느 FSD 레이어에 둘지 결정하는 흐름.
+전체 레이어 정의는 [project-structure.md](./project-structure.md).
+
+## 3단계 결정 트리
+
+새 컴포넌트가 생기면 위에서부터 차례로 답한다 — 처음 "예" 가 나오는 줄에 둔다.
+
+1. **도메인 지식이 없는 순수 UI 프리미티브인가?** (버튼, 툴팁, 입력 컴포넌트, 라벨…)
+   → `src/shared/ui/<name>/`
+   - 예: `shared/ui/tooltip`, `shared/ui/lane-selector`, `shared/ui/vote-buttons`
+
+2. **하나의 도메인 엔티티만 표현하는가?** (해당 entity 의 데이터를 받아 렌더만 함)
+   → `src/entities/<entity>/ui/`
+   - 예: `entities/champion/ui/ChampionIcon`, `entities/summoner/ui/SummonerName`
+
+3. **사용자 인터랙션/기능 단위인가?** (검색, 필터, 토글, 수정 폼…)
+   → `src/features/<feature-name>/`
+   - `model/` (스토어/훅) + `ui/` (컴포넌트) + `index.ts` 로 외부 노출
+   - 예: `features/summoner-search`, `features/match-filter`, `features/theme-toggle`
+
+4. **여러 features 를 조립한 페이지 블록인가?** (한 영역을 통째로 차지하는 복합 UI)
+   → `src/widgets/<widget-name>/`
+   - 예: `widgets/match-history`, `widgets/summoner-profile`, `widgets/champion-stats-panel`
+
+5. **하나의 라우트(페이지) 전체인가?**
+   → `src/views/<route>/ui/<Name>PageClient.tsx` ("use client")
+   - `app/<route>/page.tsx` 에서 위임 호출.
+   - 순수 SSR 페이지(patch-notes 등)는 예외로 `app/` 에 직접 둘 수 있다.
+
+## 의존성 규칙 (위반 금지)
+
+```
+app → views → widgets → features → entities → shared
+```
+
+- 동일 레이어 끼리 import 도 가급적 피한다 (cross-feature import 는 코드 결합도를 높인다).
+- 하위 → 상위 import 는 절대 금지 (`shared/ui/Foo` 가 `features/...` 를 import 하면 안 됨).
+- 외부 노출은 `index.ts` 로만 — 내부 구현 경로 직접 import 지양.
+
+## 클라이언트 / 서버 컴포넌트
+
+- 기본은 서버 컴포넌트. 상태/이벤트/브라우저 API 가 필요할 때만 `"use client"` 추가.
+- `views/*/ui/*PageClient.tsx` 는 관례적으로 client. SSR 페이지는 `app/` 에 머문다.

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -1,0 +1,56 @@
+# 개발 가이드
+
+## 사전 준비
+
+- Node.js 20+ (Next.js 16 / React 19 호환).
+- 패키지 매니저: **pnpm** (`packageManager: "pnpm@10.12.1"` 고정. lock 파일은 `pnpm-lock.yaml` 만 존재).
+
+```bash
+corepack enable          # 권장 — packageManager 필드 자동 사용
+pnpm install
+```
+
+## 환경 변수
+
+루트의 `.env.example` 을 `.env.local` 로 복사 후 채운다.
+
+| 키 | 용도 | 기본값 |
+| --- | --- | --- |
+| `NEXT_PUBLIC_API_URL` | 브라우저용 외부 API base URL | `http://localhost:8100/api` |
+| `API_URL_INTERNAL` | 서버 컴포넌트 전용 (Docker 내부 네트워크 등). 미설정 시 `NEXT_PUBLIC_API_URL` 로 fallback | `http://localhost:8100/api` |
+| `NEXT_PUBLIC_IMAGE_HOST` | 정적 이미지 호스트 | `https://static.mmrtr.shop` |
+
+> `NEXT_PUBLIC_*` 는 클라이언트 번들에 inline 됨 — 비밀값 절대 X.
+> `next.config.ts` 의 `images.remotePatterns` 에 새 호스트 추가 시 함께 업데이트.
+
+## 명령어
+
+```bash
+pnpm dev          # 개발 서버 (http://localhost:3000, hot reload)
+pnpm build        # 프로덕션 빌드 (output: standalone)
+pnpm start        # 빌드 결과 실행
+pnpm lint         # eslint 직접 실행 (next lint 가 아님 — eslint.config.mjs 사용)
+npx playwright test   # E2E 테스트
+```
+
+> 타입 체크는 `pnpm build` 가 빌드 시점에 수행. 별도 typecheck 명령은 없으니 빌드로 검증.
+
+## Git Hook
+
+`husky@9` 가 `prepare` 스크립트로 자동 설치. `.husky/pre-commit` 이 `npx lint-staged` 실행 → 변경된 `*.{js,jsx,ts,tsx}` 만 `eslint --fix`.
+
+훅 우회 (`--no-verify`) 금지 — 실패하면 원인 수정 후 재시도.
+
+## API 클라이언트 선택
+
+| 컨텍스트 | 사용 모듈 | base URL |
+| --- | --- | --- |
+| 브라우저 / `"use client"` | `@/shared/api/client` | `NEXT_PUBLIC_API_URL` |
+| 서버 컴포넌트 / 서버 액션 | `@/shared/api/server-client` | `API_URL_INTERNAL` (없으면 `NEXT_PUBLIC_API_URL`) |
+
+브라우저 클라이언트는 401 자동 토큰 갱신 + 로그인 페이지 redirect 인터셉터 포함 (`/auth/refresh`, `/auth/logout` 은 재시도 제외).
+
+## 같이 보기
+
+- [프로젝트 구조](./project-structure.md) — 코드 어디에 둘지
+- [라이브러리](./libraries.md) — 무엇을 쓰고 무엇을 피할지

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -1,0 +1,45 @@
+# 라이브러리 / 의존성
+
+`package.json` 기준. 각 줄의 마지막은 "**왜 / 언제 쓰지 마라**".
+
+## Framework / 언어
+
+| 라이브러리 | 용도 | 메모 |
+| --- | --- | --- |
+| `next@16` (App Router) | SSR / 라우팅 / 빌드 | App Router 만 사용. Pages Router 신규 추가 X |
+| `react@19`, `react-dom@19` | UI | Server / Client 컴포넌트 분리 — 기본은 server |
+| `typescript@5` | 타입 | `strict: true`. `any` 금지. `paths: @/* → ./src/*` |
+
+## 데이터 / 상태
+
+| 라이브러리 | 용도 | 왜 / 언제 쓰지 마라 |
+| --- | --- | --- |
+| `@tanstack/react-query@5` | 서버 데이터 캐싱·동기화 | 비동기 서버 데이터는 React Query 가 단일 출구. 단순 클라 상태에는 X (그건 Zustand). 캐시 키는 `entities/*/model/` 안에 정의 |
+| `zustand@5` | 클라이언트 전역 상태 | 글로벌 UI 상태 (테마, 게임 데이터 캐시 등). 서버 데이터에는 X — React Query 와 역할 분리 유지 |
+| `axios@1` | HTTP 클라이언트 | 인터셉터로 401 토큰 갱신 + 로깅. fetch 직접 호출 대신 `shared/api/client.ts` (브라우저) / `server-client.ts` (서버) 사용 |
+| `zod@4` | 스키마 검증 | 폼 검증 + 외부 입력 파싱. 내부 타입 합성용으로는 과함 |
+| `react-hook-form@7` + `@hookform/resolvers` | 폼 상태 | 폼 컴포넌트는 RHF + Zod resolver 패턴. 단일 input 토글 같은 사소한 폼은 그냥 `useState` |
+
+## UI / 시각화
+
+| 라이브러리 | 용도 | 메모 |
+| --- | --- | --- |
+| `tailwindcss@4` (+ `@tailwindcss/postcss`) | 스타일링 | 토큰은 `globals.css` `@theme inline` 블록. 자세한 룰은 [styling-guide.md](./styling-guide.md) |
+| `lucide-react` | 아이콘 | SVG 아이콘은 lucide 를 우선. 커스텀 SVG 는 `shared/ui/` |
+| `chart.js@4` + `react-chartjs-2@5` | 차트 | 챔피언/매치 통계 시각화. 가벼운 막대/도넛이면 그냥 div 로 충분 |
+| `react-error-boundary@6` | 에러 바운더리 | widget/feature 단위 격리. 페이지 전체 fallback 은 Next.js `error.tsx` 로 |
+| `dayjs@1` | 날짜/시간 | timezone 무거운 케이스 외엔 dayjs. moment 신규 추가 X |
+
+## 개발 / 품질
+
+| 라이브러리 | 용도 |
+| --- | --- |
+| `eslint@9` + `eslint-config-next@16` | 린트 — `pnpm lint` (next lint 아님) |
+| `husky@9` + `lint-staged@16` | pre-commit 에서 변경 파일만 `eslint --fix` |
+| `@playwright/test@1` | E2E — `npx playwright test` |
+| `@tanstack/react-query-devtools` | dev 모드 React Query devtools (자동 마운트) |
+
+## 같이 보기
+
+- [개발 가이드](./development-guide.md) — 명령어 / 환경 변수
+- [스타일링 가이드](./styling-guide.md) — Tailwind v4 토큰

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,0 +1,41 @@
+# 프로젝트 구조
+
+Next.js 16 App Router + Feature-Sliced Design (FSD).
+의존성 방향은 단방향 — 상위 레이어만 하위 레이어를 import한다.
+
+```
+app → views → widgets → features → entities → shared
+```
+
+## 레이어
+
+| 레이어 | 역할 | 예시 |
+| --- | --- | --- |
+| `src/app/` | Next.js 라우팅 / 레이아웃 / 메타데이터 / SSR 진입점 | `app/champion-stats/page.tsx` |
+| `src/views/` | 페이지 단위 클라이언트 컴포넌트 (`*PageClient.tsx`) | `views/champion-stats/ui/...` |
+| `src/widgets/` | 여러 features를 조립하는 복합 UI 블록 | `widgets/match-history`, `widgets/summoner-profile` |
+| `src/features/` | 사용자 인터랙션 단위 기능 (검색, 필터, 토글…) | `features/summoner-search`, `features/match-filter` |
+| `src/entities/` | 도메인 엔티티 — `api/`, `model/`, `lib/`, `ui/`, `types.ts` | `entities/summoner`, `entities/match`, `entities/champion` |
+| `src/shared/` | 재사용 인프라 (api, lib, ui, providers, model, constants, config) | `shared/api/client.ts`, `shared/providers/QueryProvider.tsx` |
+
+> `views/` 가 따로 있는 이유: Next.js 의 `pages/` 가 예약어라 충돌을 피하기 위함.
+> 패치노트 페이지는 순수 SSR 이라 `views/` 를 거치지 않고 `app/patch-notes/` 에 머문다 (예외).
+
+## SSR vs CSR
+
+- **SSR** — `app/patch-notes/`, `app/leaderboards/` : 서버에서 데이터 fetching 후 HTML 으로 렌더.
+- **CSR** — `app/champion-stats/`, `app/summoners/` : `app/<route>/page.tsx` 가 `views/<route>/ui/*PageClient.tsx` ("use client") 로 위임.
+
+## 데이터 흐름
+
+```
+Component → React Query hook (entities/*/model/) → API 함수 (entities/*/api/) → backend
+                              ↓
+            Zustand store (shared/model/, entities/*/model/, features/*/model/)
+```
+
+## 같이 보기
+
+- [컴포넌트 작성 가이드](./component-guide.md) — 새 컴포넌트를 어디 둘지 결정 트리
+- [라이브러리](./libraries.md) — 각 레이어에서 쓰는 의존성
+- [개발 가이드](./development-guide.md) — 실행/빌드/lint

--- a/docs/styling-guide.md
+++ b/docs/styling-guide.md
@@ -1,0 +1,41 @@
+# 스타일링 가이드
+
+Tailwind CSS v4 + CSS 변수 기반 토큰. 다크/라이트 동시 지원.
+
+## 토큰 정의 — `src/app/globals.css`
+
+`globals.css` 한 파일에서 두 단계로 토큰을 정의한다.
+
+1. **`:root, html.dark` / `html.light`** 블록 — 원시 CSS 변수 (`--md-*`).
+   - Material Design 다크 테마 기반 elevation (`--md-elevation-0` ~ `--md-elevation-24`).
+   - 텍스트 불투명도 (`--md-text-high/medium/disabled`), 구분선 (`--md-divider`).
+   - 액센트 (`--md-primary/secondary/error/success/warning`).
+   - LoL 시맨틱: `--md-win`, `--md-loss`, `--md-team-blue`, `--md-team-red`, `--md-gold`, `--md-rank-top`, `--md-rank-high`.
+   - 통계: `--md-stat-low/mid/high/perfect/neutral`.
+   - 패치노트 변경유형: `--md-buff`, `--md-nerf`, `--md-adjust`, `--md-info`.
+
+2. **`@theme inline { ... }`** 블록 — 위 변수들을 Tailwind v4 의 `--color-*` 네임스페이스로 노출.
+   → Tailwind 가 자동으로 `bg-primary`, `text-on-surface`, `border-divider`, `bg-surface-2`, `text-win`, `text-buff` 같은 유틸리티를 생성한다.
+
+## 사용 규칙
+
+- 유틸리티 우선. 색상은 토큰만 사용 — `bg-[#1E1E1E]` 같은 임의 값 금지.
+- 새 색이 필요하면 `globals.css` 의 두 블록(`html.dark` / `html.light`) 모두에 변수를 추가하고 `@theme inline` 에 노출.
+- 표면색은 `bg-surface`, `bg-surface-1` … `bg-surface-24` 로 깊이 조절. 카드/팝오버는 보통 `surface-2` ~ `surface-8`.
+- 텍스트는 `text-on-surface` (87%) / `text-on-surface-medium` (60%) / `text-on-surface-disabled` (38%).
+- 승/패, 팀 색은 반드시 시맨틱 토큰 (`text-win`, `bg-team-blue`) — 직접 색상 코드 X.
+
+## 다크 / 라이트 전환
+
+- 스토어: `src/features/theme-toggle/model/useThemeStore.ts` (Zustand + `persist`, key `theme-storage`, 기본값 `dark`).
+- 적용: `src/shared/providers/ThemeProvider.tsx` 가 `<html>` 의 클래스를 `dark` ↔ `light` 로 토글.
+- 토글 UI: `src/features/theme-toggle/ui/ThemeToggle.tsx` (`useThemeStore().toggleTheme`).
+
+## 글로벌 애니메이션
+
+`globals.css` 하단에 `pulse-glow` / `fade-in-up` / `float` / `rank-shimmer` / `crown-glow` / `tooltip-fade-in` keyframe + `.animate-*` 유틸 클래스. 페이지 단위 애니메이션은 컴포넌트 안에서 정의하고 글로벌은 재사용 가능한 것만.
+
+## 같이 보기
+
+- [컴포넌트 작성 가이드](./component-guide.md) — UI 프리미티브는 `shared/ui/` 에
+- [개발 가이드](./development-guide.md) — `pnpm dev` 로 핫 리로드


### PR DESCRIPTION
## Summary
- README 가 가리키던 `docs/` 5건 broken refs 해소 — 실 파일로 작성 (project-structure / component-guide / libraries / styling-guide / development-guide).
- README 78→32줄로 정리. 구식 `src/components/` 설명을 제거(실제 코드는 FSD 구조), 패키지 매니저 표기를 `npm` → `pnpm` 으로 바로잡음.
- 각 docs 41~56줄, 사실 기반(코드/설정 grep으로 확인)으로 작성.

## Why
MP-23 audit 에서 lol-ui 가 34/100 (AI-Hostile) 으로 평가됨. E1 broken_path_refs 차감 주범이 README 의 `./docs/` 링크 5건이었음. 신규 진입자(AI 에이전트 포함) 가 한 번에 사실에 도달하도록 docs 5종을 채움.

## Test plan
- [ ] CI 통과 (lint / build)
- [ ] README 모든 `./docs/*.md` 링크가 실제 파일을 가리킴
- [ ] 각 docs 가 실제 코드/설정과 일치 (package.json, src/ 구조, .env.example, globals.css)

Closes MP-28

🤖 Generated by Padosol