### PR TITLE
feat: MP-7 솔로/자유 랭크 챔피언 통계 단일 호출 통합

### DIFF
--- a/src/entities/match/api/matchApi.ts
+++ b/src/entities/match/api/matchApi.ts
@@ -2,8 +2,8 @@ import type { ApiResponse } from "@/shared/api/types";
 import type {
   DailyMatchCountResponse,
   MatchDetail,
-  ChampionStat,
   MatchIdsResponse,
+  RankChampionsResponse,
   SummonerMatchesResponse,
 } from "../types";
 import { apiClient } from "@/shared/api/client";
@@ -75,16 +75,14 @@ export async function getDailyMatchCount(
 export async function getChampionRanking(
   puuid: string,
   season: string,
-  queueId?: number,
   platform?: string
-): Promise<ChampionStat[]> {
-  const response = await apiClient.get<ApiResponse<ChampionStat[]>>(
+): Promise<RankChampionsResponse> {
+  const response = await apiClient.get<ApiResponse<RankChampionsResponse>>(
     `/v1/rank/champions`,
     {
       params: {
         puuid,
         season,
-        ...(queueId !== undefined && { queueId }),
         ...(platform !== undefined && { platform }),
       },
     }

--- a/src/entities/match/index.ts
+++ b/src/entities/match/index.ts
@@ -9,4 +9,5 @@ export type {
   ChampionStat, ItemData, RuneSelection, RuneStyleEntry, RuneStyle,
   StatValue, ItemSeqEntry, SkillSeqEntry, MatchIdsResponse,
   SummonerMatchesResponse, DailyMatchCount, DailyMatchCountResponse,
+  RankChampionsResponse,
 } from "./types";

--- a/src/entities/match/model/useChampionRanking.ts
+++ b/src/entities/match/model/useChampionRanking.ts
@@ -1,16 +1,15 @@
 import { getChampionRanking } from "../api/matchApi";
-import type { ChampionStat } from "../types";
+import type { RankChampionsResponse } from "../types";
 import { useQuery } from "@tanstack/react-query";
 
 export function useChampionRanking(
   puuid: string,
   season: string,
-  queueId?: number,
   platform?: string
 ) {
-  return useQuery<ChampionStat[], Error>({
-    queryKey: ["champion", "ranking", puuid, season, queueId, platform],
-    queryFn: () => getChampionRanking(puuid, season, queueId, platform),
+  return useQuery<RankChampionsResponse, Error>({
+    queryKey: ["champion", "ranking", puuid, season, platform],
+    queryFn: () => getChampionRanking(puuid, season, platform),
     enabled: !!puuid && !!season,
     staleTime: 5 * 60 * 1000,
   });

--- a/src/entities/match/types.ts
+++ b/src/entities/match/types.ts
@@ -211,3 +211,8 @@ export interface DailyMatchCountResponse {
   minCount: number;
   maxCount: number;
 }
+
+export interface RankChampionsResponse {
+  solo: ChampionStat[];
+  flex: ChampionStat[];
+}

--- a/src/widgets/summoner-profile/ui/ChampionStats.tsx
+++ b/src/widgets/summoner-profile/ui/ChampionStats.tsx
@@ -29,11 +29,12 @@ export default function ChampionStats({
   const latestSeasonValue = useSeasonStore((s) => s.getLatestSeasonValue());
   const effectiveSeason = season ?? latestSeasonValue ?? "";
 
-  const { data: championStats = [], isLoading } = useChampionRanking(
+  const { data, isLoading } = useChampionRanking(
     puuid || "",
-    effectiveSeason,
-    420
+    effectiveSeason
   );
+
+  const championStats = data?.solo ?? [];
 
   const [sortField, setSortField] = useState<SortField>("playCount");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");

--- a/src/widgets/summoner-profile/ui/ChampionStatsOverview.tsx
+++ b/src/widgets/summoner-profile/ui/ChampionStatsOverview.tsx
@@ -34,13 +34,13 @@ export default function ChampionStatsOverview({
   const effectiveSeason = season ?? latestSeasonValue ?? "";
 
   const [activeQueue, setActiveQueue] = useState<QueueTabType>("solo");
-  const queueId = activeQueue === "solo" ? 420 : 440;
 
-  const { data: championStats = [], isLoading } = useChampionRanking(
+  const { data, isLoading } = useChampionRanking(
     puuid || "",
-    effectiveSeason,
-    queueId
+    effectiveSeason
   );
+
+  const championStats = data?.[activeQueue] ?? [];
 
   // champion.json 데이터 로드 (zustand store 사용)
   const loadChampionData = useGameDataStore((state) => state.loadChampionData);


### PR DESCRIPTION
## Summary
서버 `/api/v1/rank/champions` 응답이 split 형태(`{solo, flex}`)로 변경됨에 맞춰 탭 전환 시 두 번 호출하던 UI 호출 구조를 단일 호출로 통합.

## Changes
- `getChampionRanking`: `queueId` 인자 제거, 응답 타입 `RankChampionsResponse` 로 변경
- `useChampionRanking`: 캐시 키에서 `queueId` 제거 (`puuid + season + platform`)
- `ChampionStatsOverview`: 한 번 호출 후 `activeQueue` ('solo' | 'flex') 에 따라 `data.solo` / `data.flex` 분기 렌더 (default `solo`)
- `ChampionStats`: 하드코딩된 `queueId 420` 제거, `data.solo` 사용
- `types`: `RankChampionsResponse` (`{ solo: ChampionStat[]; flex: ChampionStat[] }`) 타입 신규 추가

## 검증
- `pnpm exec tsc --noEmit` 통과
- `pnpm build` 통과 (Next.js 16.1.6, 18 페이지 정상 생성)
- 실 백엔드 연동 e2e 는 server PR 머지 후 수동 확인 예정

## Related
Related to MP-7 (server PR 와 병렬 진행 — `Closes` 는 server PR 가 가져감)

🤖 Generated by Padosol