### PR TITLE
[MP-37] fix: 챔피언 통계 상세에서 skillBuild가 null인 항목 숨기기

### DIFF
--- a/src/entities/champion/types.ts
+++ b/src/entities/champion/types.ts
@@ -60,7 +60,7 @@ export interface RuneBuildData extends BuildConfidenceMeta {
 }
 
 export interface SkillBuildData extends BuildConfidenceMeta {
-  skillBuild: string; // BQ: "[1,2,1,2,2,3,...]" / 레거시: "Q,E,W,Q,Q,R,..."
+  skillBuild: string | null; // BQ: "[1,2,1,2,2,3,...]" / 레거시: "Q,E,W,Q,Q,R,..." / null: 데이터 부족
   games: number;
   winRate: number;
   pickRate: number;

--- a/src/widgets/champion-stats-panel/ui/SkillTreeStats.tsx
+++ b/src/widgets/champion-stats-panel/ui/SkillTreeStats.tsx
@@ -71,16 +71,21 @@ export default function SkillTreeStats({
   const [expanded, setExpanded] = useState(false);
   const championData = useGameDataStore((s) => s.championData);
   const champion = championData?.data[championName];
-  if (data.length === 0) return null;
 
-  const visible = expanded ? data : data.slice(0, DEFAULT_VISIBLE);
+  const filtered = data.filter(
+    (b): b is SkillBuildData & { skillBuild: string } =>
+      b.skillBuild != null && b.skillBuild.trim() !== "",
+  );
+  if (filtered.length === 0) return null;
+
+  const visible = expanded ? filtered : filtered.slice(0, DEFAULT_VISIBLE);
 
   return (
     <div className="bg-surface-1 rounded-lg border border-divider p-0 md:p-5">
       <StatSectionHeader
         title="스킬 트리"
-        totalCount={data.length}
-        visibleCount={Math.min(DEFAULT_VISIBLE, data.length)}
+        totalCount={filtered.length}
+        visibleCount={Math.min(DEFAULT_VISIBLE, filtered.length)}
         expanded={expanded}
         onToggle={() => setExpanded((v) => !v)}
       />


### PR DESCRIPTION
변경 타입: fix

## Summary
- `SkillBuildData.skillBuild` 타입을 `string | null` 로 보정 (서버 응답에 null 섞이는 케이스 반영)
- `SkillTreeStats` 에서 `skillBuild` 가 null/공백인 항목을 렌더링 직전에 필터링 — `null.trim()/.split()` 런타임 에러 방지
- `totalCount`/`visibleCount`/`visible` 모두 필터된 배열 기준으로 일관 계산. 필터 후 0건이면 컴포넌트 자체 `null` 반환

## Test plan
- [x] `pnpm tsc --noEmit` 통과
- [x] `pnpm lint` — 신규 에러 없음 (사전 warning 만 존재)
- [ ] (수동) 챔피언 통계 상세 페이지에서 스킬 트리 섹션 정상 렌더 확인
- [ ] (수동) 일부 빌드의 skillBuild 가 null 인 케이스에서 그 행만 누락되고 나머지는 정상 노출

Closes MP-37