### PR TITLE
fix(MP-20): 챔피언 분석 좌측 리스트 간격 축소

### DIFF
--- a/src/widgets/champion-stats-panel/ui/ChampionListSidebar.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionListSidebar.tsx
@@ -50,13 +50,13 @@ export default function ChampionListSidebar({
       </div>
 
       {/* 챔피언 목록 */}
-      <div className="grid grid-cols-5 gap-1.5">
+      <div className="grid grid-cols-5 gap-0.5">
         {champions.map((champ) => (
           <Link
             prefetch={false}
             key={champ.id}
             href={`/champion-stats/${champ.id}?tier=${tier}&patch=${patch}&platformId=${platformId}`}
-            className="flex flex-col items-center gap-1 p-1.5 rounded transition-colors text-on-surface-medium hover:bg-surface-4 hover:text-on-surface"
+            className="flex flex-col items-center gap-1 p-1 rounded transition-colors text-on-surface-medium hover:bg-surface-4 hover:text-on-surface"
           >
             <Image
               src={getChampionImageUrl(champ.id)}


### PR DESCRIPTION
**Type: fix**

## Summary
- 챔피언 분석 페이지(`/champion-stats`) 좌측 `ChampionListSidebar` 의 챔피언 그리드 간격이 너무 넓어 세로로 늘어져 보이는 문제 수정.
- 그리드 `gap-1.5` (6px) → `gap-0.5` (2px), 각 항목 `p-1.5` (6px) → `p-1` (4px) 로 축소.

## 변경 범위 (MP-21 충돌 검증)
- 단일 파일만 수정: `src/widgets/champion-stats-panel/ui/ChampionListSidebar.tsx`
- `entities/champion` 공유 타입 / 공통 layout 컴포넌트 **미접촉**
- 순수 Tailwind 클래스 값 변경 (스펙/시그니처 변경 없음)
- MP-21 (챔피언 분석 **상세** 페이지 timeline 제거) 와 영역 완전 분리됨

## Before / After
스크린샷 자동화 불가 — 수동 검증 필요.

수치 비교:
| 항목 | before | after |
| --- | --- | --- |
| 그리드 row/col gap | 6px (`gap-1.5`) | 2px (`gap-0.5`) |
| 항목 padding | 6px (`p-1.5`) | 4px (`p-1`) |
| 항목 row pitch (예상) | ~78px | ~70px |

## Test plan
- [ ] `/champion-stats` 페이지 데스크톱 lg 브레이크포인트에서 좌측 챔피언 리스트가 더 조밀하게 보이는지 시각 확인
- [ ] 챔피언 항목 hover/클릭 동작이 기존과 동일한지 확인
- [ ] 모바일/태블릿(lg 미만)에서는 사이드바가 숨겨져 영향 없음 확인
- [ ] 검색 입력 시 필터링 결과 레이아웃 정상 확인

Closes MP-20