### PR TITLE
[MP-17] fix: 챔피언 분석 상세페이지 UI 고도화

### DIFF
--- a/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
+++ b/src/views/champion-stats/ui/ChampionStatsDetailPageClient.tsx
@@ -72,6 +72,17 @@ export default function ChampionStatsDetailPageClient({
     return data.positions.map((p) => p.teamPosition);
   }, [data]);
 
+  // 포지션별 totalGames 비율 (탭 % 표시용)
+  const positionShares = useMemo(() => {
+    if (!data?.positions || data.positions.length === 0) return undefined;
+    const total = data.positions.reduce((sum, p) => sum + (p.totalGames ?? 0), 0);
+    if (total <= 0) return undefined;
+    return data.positions.reduce<Partial<Record<ApiPositionType, number>>>((acc, p) => {
+      acc[p.teamPosition] = (p.totalGames ?? 0) / total;
+      return acc;
+    }, {});
+  }, [data]);
+
   // 유효한 포지션 계산: 선택된 포지션이 없거나 목록에 없으면 첫 번째 포지션으로 fallback
   const effectivePosition = useMemo(() => {
     if (selectedPosition && availablePositions.includes(selectedPosition)) {
@@ -105,6 +116,7 @@ export default function ChampionStatsDetailPageClient({
             selectedPosition={effectivePosition ?? "TOP"}
             onSelectPosition={setSelectedPosition}
             availablePositions={availablePositions.length > 0 ? availablePositions : undefined}
+            positionShares={positionShares}
           />
 
           {isLoading ? (

--- a/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionOverview.tsx
@@ -67,6 +67,9 @@ export default function ChampionOverview({
     : "표본 부족";
   const kdaScore = hasAverages ? `KDA ${formatAvg(averages?.kda, 2)}` : "";
 
+  const wins = Math.round(data.totalGames * data.winRate);
+  const losses = data.totalGames - wins;
+
   return (
     <div className="bg-surface-1 rounded-lg border border-divider p-3 sm:p-5">
       <div className="flex items-center gap-3 sm:gap-4">
@@ -90,11 +93,6 @@ export default function ChampionOverview({
             >
               {displayedTier}
             </span>
-          </div>
-          <div className="text-xs text-on-surface-medium">
-            <span>픽률 {formatRate(data.pickRate)}</span>
-            <span className="mx-1.5">·</span>
-            <span>밴률 {formatRate(data.banRate)}</span>
           </div>
           <div className="flex items-center gap-1.5 flex-wrap">
             {champion?.passive && (
@@ -138,14 +136,17 @@ export default function ChampionOverview({
           value={formatRate(data.winRate)}
           valueClass={data.winRate >= 0.5 ? "text-win" : "text-loss"}
         />
-        <StatCard
-          label="승리"
-          value={Math.round(data.totalGames * data.winRate).toLocaleString()}
-        />
+        <StatCard label="픽률" value={formatRate(data.pickRate)} />
+        <StatCard label="밴률" value={formatRate(data.banRate)} />
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 mt-2">
         <StatCard
           label="게임수"
           value={data.totalGames.toLocaleString()}
         />
+        <StatCard label="승리" value={wins.toLocaleString()} />
+        <StatCard label="패배" value={losses.toLocaleString()} />
       </div>
 
       <div className="grid grid-cols-3 gap-2 mt-2">

--- a/src/widgets/champion-stats-panel/ui/PositionTabs.tsx
+++ b/src/widgets/champion-stats-panel/ui/PositionTabs.tsx
@@ -10,12 +10,14 @@ interface PositionTabsProps {
   selectedPosition: ApiPositionType;
   onSelectPosition: (position: ApiPositionType) => void;
   availablePositions?: ApiPositionType[];
+  positionShares?: Partial<Record<ApiPositionType, number>>;
 }
 
 export default function PositionTabs({
   selectedPosition,
   onSelectPosition,
   availablePositions,
+  positionShares,
 }: PositionTabsProps) {
   const positions = availablePositions ?? ALL_POSITIONS;
 
@@ -23,6 +25,9 @@ export default function PositionTabs({
     <div className="flex border-b border-divider overflow-x-auto scrollbar-thin">
       {positions.map((pos) => {
         const isActive = pos === selectedPosition;
+        const share = positionShares?.[pos];
+        const sharePercent =
+          share != null && Number.isFinite(share) ? Math.round(share * 100) : null;
         return (
           <button
             key={pos}
@@ -43,6 +48,9 @@ export default function PositionTabs({
               className={isActive ? "opacity-100" : "opacity-60"}
             />
             <span className="hidden sm:inline">{getPositionName(pos)}</span>
+            {sharePercent != null && (
+              <span className="text-xs text-on-surface-medium">{sharePercent}%</span>
+            )}
           </button>
         );
       })}


### PR DESCRIPTION
## Summary
- 포지션 탭에 `data.positions[].totalGames` 합 대비 비율(%)을 라벨 옆에 표기
- ChampionOverview 헤더의 `픽률 X% · 밴률 Y%` 한 줄 텍스트를 제거하고, 메트릭 카드 3x3로 재구성
  - Row1: 승률 / 픽률 / 밴률
  - Row2: 게임수 / 승리 / 패배 (승리 = round(totalGames × winRate), 패배 = totalGames − 승리)
  - Row3: KDA / 분당 골드 / 10분 CS
- 신규 API 호출/모델 변경 없음, 기존 `useChampionStats` 응답 필드만 활용

## Test plan
- [x] `pnpm lint` (errors 0, 기존 warning 그대로)
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm build` 통과
- [ ] 챔피언 상세 페이지 렌더 — 포지션 탭 % 노출, 카드 3x3 정상 표시

Closes MP-17