### PR TITLE
fix(MP-40): 소환사 프로필 헤더 태그라인 단독 줄바꿈 방지

### DIFF
--- a/src/widgets/summoner-profile/ui/ProfileSection.tsx
+++ b/src/widgets/summoner-profile/ui/ProfileSection.tsx
@@ -257,12 +257,14 @@ export default function ProfileSection({
               {/* 프로필 이름 */}
               <div>
                 <h1 className="text-lg md:text-xl font-bold text-on-surface break-words">
-                  {profileData.gameName || summonerName}
-                  {profileData.tagLine && (
-                    <span className="text-on-surface-medium ml-1 md:ml-2 text-sm md:text-base">
-                      #{profileData.tagLine}
-                    </span>
-                  )}
+                  <span className="whitespace-nowrap">
+                    {profileData.gameName || summonerName}
+                    {profileData.tagLine && (
+                      <span className="text-on-surface-medium ml-1 md:ml-2 text-sm md:text-base">
+                        #{profileData.tagLine}
+                      </span>
+                    )}
+                  </span>
                 </h1>
               </div>
 


### PR DESCRIPTION
## Summary
- `gameName` 과 `#tagLine` 을 `whitespace-nowrap` span 으로 묶어, 태그라인이 단독으로 다음 줄에 떨어져 헤더 레이아웃이 깨지는 현상 차단
- 모바일·데스크톱 동일 적용 (별도 분기 없음). truncate 미적용 (B 방향 채택)

## Affected
- src/widgets/summoner-profile/ui/ProfileSection.tsx (h1 태그 내부)

## Test plan
- [ ] 데스크톱: 긴 tagLine 으로 헤더 한 줄 유지 확인
- [ ] 모바일: 긴 tagLine 으로 헤더 한 줄 유지 확인
- [ ] gameName 만으로 줄이 넘칠 정도로 길 때 자연스럽게 wrap 되는지 확인

Closes MP-40