### PR TITLE
chore: MP-41 CLAUDE.md 브랜치 prefix 표 정리 (예시 열 + kebab 표현)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,13 +54,13 @@ Component → React Query hook (entities/*/model/) → API함수 (entities/*/api
 
 ## Git Workflow
 
-브랜치 네이밍: `<type>/MP-<번호>-<kebab-설명>` → `develop` → `main`. 핫픽스만 예외로 `hotfix/MP-<번호>-*` → `main` → `develop` 역머지.
+브랜치 네이밍: `<type>/MP-<번호>-<kebab-case 설명>` → `develop` → `main`. 핫픽스만 예외로 `hotfix/MP-<번호>-*` → `main` → `develop` 역머지.
 
-| prefix | 설명 |
-| --- | --- |
-| `feature` | 신규 기능 |
-| `fix` | 버그 수정 |
-| `refactor` | 동작 변화 없는 구조 개선 |
-| `chore` | 코드 영향 없는 산출물·문서·CI·도구 변경 (의존 업그레이드, audit 산출물, lint 룰 추가 등) |
-| `docs` | 사용자/개발자 문서 |
-| `hotfix` | 긴급 prod 패치 (main 직접 분기) |
+| prefix | 설명 | 예시 |
+| --- | --- | --- |
+| `feature` | 신규 기능 | `feature/MP-7-summoner-search` |
+| `fix` | 버그 수정 | `fix/MP-12-match-null-check` |
+| `refactor` | 동작 변화 없는 구조 개선 | `refactor/MP-7-mapper-cleanup` |
+| `chore` | 코드 영향 없는 산출물·문서·CI·도구 변경 (의존 업그레이드, audit 산출물, lint 룰 추가 등) | `chore/MP-41` |
+| `docs` | 사용자/개발자 문서 | `docs/MP-20-workflow-guide` |
+| `hotfix` | 긴급 prod 패치 (main 직접 분기) | `hotfix/MP-34-login-500` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,6 @@ Component → React Query hook (entities/*/model/) → API함수 (entities/*/api
 | `feature` | 신규 기능 | `feature/MP-7-summoner-search` |
 | `fix` | 버그 수정 | `fix/MP-12-match-null-check` |
 | `refactor` | 동작 변화 없는 구조 개선 | `refactor/MP-7-mapper-cleanup` |
-| `chore` | 코드 영향 없는 산출물·문서·CI·도구 변경 (의존 업그레이드, audit 산출물, lint 룰 추가 등) | `chore/MP-41` |
+| `chore` | 코드 영향 없는 산출물·문서·CI·도구 변경 (의존 업그레이드, audit 산출물, lint 룰 추가 등) | `chore/MP-41-claude-md-prefix-table` |
 | `docs` | 사용자/개발자 문서 | `docs/MP-20-workflow-guide` |
 | `hotfix` | 긴급 prod 패치 (main 직접 분기) | `hotfix/MP-34-login-500` |


### PR DESCRIPTION
## Summary

- `Git Workflow` 섹션의 prefix 표를 2열 → 3열 (`prefix | 설명 | 예시`) 로 확장. 각 prefix 의 실제 브랜치명 형태 예시를 한 개씩 추가해 처음 보는 사람이 표만 보고 즉시 사용할 수 있게 함.
- 브랜치 네이밍 설명에서 한영 혼용된 `<kebab-설명>` → `<kebab-case 설명>` 으로 표현 통일.

빌드/런타임 영향 없음 (docs only).

Closes MP-41

## Test plan

- [x] `git diff` 로 변경 라인 = 의도한 두 항목만 확인
- [ ] CI lint/build 통과