### PR TITLE
chore: MP-84 release-please target-branch=main 명시

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: node
+          target-branch: main


### PR DESCRIPTION
## Summary
- GitHub default branch=develop 인 환경에서 release-please-action v4 가 default branch 를 자동 선택해 develop 에 release PR (#175) 을 만드는 문제 fix
- workflow trigger 는 그대로 `push to main` 유지, action 에 `target-branch: main` 한 줄 명시
- default branch 자체는 변경하지 않음 (PR base 가 develop 인 게 표준 흐름)

## 변경
- `.github/workflows/release-please.yml` — `with` 블록에 `target-branch: main` 추가

## 후속
- 이 PR 머지 후 develop → main 머지(다음 release 사이클) 시점에 main 의 workflow 정의 갱신
- 그 이후 main push 시 release-please bot 이 main base 의 release PR 만 갱신/생성
- 잔여 PR #175 (chore(develop): release 1.11.0) 는 머지하지 않고 close 권장

## 관련 이슈
- MP-84: https://linear.app/metapick/issue/MP-84/
- 배경: PR #139 stale + PR #175 develop 생성 (조사 결과)

## Test plan
- [ ] develop → main 머지 후 main push event 발생 시 release-please bot 이 main 에 (base=main) release PR 만 만드는지 확인
- [ ] develop 에는 더 이상 release PR 이 만들어지지 않는지 확인