### PR TITLE
release: develop → main (MP-84 release-please target-branch 명시 반영)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: node
+          target-branch: main


### PR DESCRIPTION
## Summary

develop 의 변경을 main 으로 반영하는 sync PR.

## 포함 변경

- **PR #176 (MP-84)**: `release-please.yml` 에 `target-branch: main` 명시
  - default branch 가 main 으로 바뀌어 동작상은 redundant 하지만, 명시 설정으로 안전망 유지

## 부수 효과 (의도된)

- 이 main 머지로 CI 후 deploy workflow_run 정상 트리거되는지 관찰 — 직전 사이클 (51e625b) 에서 Deploy 가 누락된 이슈가 있어 회복 여부 확인용

## 비포함

- 1.11.0 CHANGELOG 의 5월 작업 누락분은 별도 정리 (다음 release-please PR 에서 캐치 여부 확인 후 결정)

## Test plan

- [ ] CI 통과
- [ ] 머지 후 Deploy workflow_run 트리거 확인
- [ ] ECR push & SSM 배포 chain 정상 동작