### PR TITLE
fix: MP-80 champion-stats list→detail 라우팅 tier + suffix 보존

### DIFF
--- a/src/widgets/champion-stats-panel/ui/ChampionListSidebar.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionListSidebar.tsx
@@ -55,7 +55,7 @@ export default function ChampionListSidebar({
           <Link
             prefetch={false}
             key={champ.id}
-            href={`/champion-stats/${champ.id}?tier=${tier}&patch=${patch}&platformId=${platformId}`}
+            href={`/champion-stats/${champ.id}?tier=${encodeURIComponent(tier)}&patch=${patch}&platformId=${platformId}`}
             className="flex flex-col items-center gap-1 p-1 rounded transition-colors text-on-surface-medium hover:bg-surface-4 hover:text-on-surface"
           >
             <Image

--- a/src/widgets/champion-stats-panel/ui/ChampionStatsTable.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionStatsTable.tsx
@@ -114,7 +114,7 @@ export default function ChampionStatsTable({
               <Link
                 prefetch={false}
                 key={entry.championId}
-                href={`/champion-stats/${championId}?tier=${tier}&patch=${patch}&platformId=${platformId}`}
+                href={`/champion-stats/${championId}?tier=${encodeURIComponent(tier)}&patch=${patch}&platformId=${platformId}`}
                 className="grid grid-cols-[80px_60px_1fr_1fr_1fr] items-center px-4 py-2.5 hover:bg-surface-4 transition-colors border-b border-divider last:border-b-0"
               >
                 {content}


### PR DESCRIPTION
## 요약

챔피언 분석 list 페이지에서 `tier=grandmaster+` (또는 `master+`, `challenger+`, `gold+` 등 모든 plus 변형) 로 진입 시 detail 페이지가 `+` 가 없는 단일 티어로 보여 사용자 혼란을 일으키는 버그를 수정.

Closes MP-80 — https://linear.app/padosol/issue/MP-80

## Root Cause

- `ChampionListSidebar.tsx:58` / `ChampionStatsTable.tsx:117` 의 Link href:
  ```tsx
  href={`/champion-stats/${id}?tier=${tier}&patch=${patch}&platformId=${platformId}`}
  ```
- `tier` 값에 포함된 `+` 가 template literal 로 raw 보간되어 URL 에 그대로 들어감 → `?tier=GRANDMASTER+`.
- URL query string 표준 디코딩 (`application/x-www-form-urlencoded`) 규칙상 `+` 는 공백으로 풀린다.
- 결과: detail 페이지의 `searchParams.tier === \"GRANDMASTER \"` (trailing space).

### server 측은 정상 (선행 워커 MP-80/server MockMvc 검증)

| @RequestParam(\"tier\") 수신값 | 결과 |
|---|---|
| `\"GRANDMASTER \"` (trailing space — raw `+` 디코딩) | TierFilter GRANDMASTER+ ✅ |
| `\"GRANDMASTER+\"` (%2B 인코딩으로 도달) | TierFilter GRANDMASTER+ ✅ |
| `\"MASTER \"` (trailing space) | TierFilter MASTER+ ✅ |
| `\"GRANDMASTER\"` (+ 누락) | TierFilter GRANDMASTER (단일 — 의도된 동작) |

server 는 trailing space 도 GRANDMASTER+ 로 정상 매핑하므로 API 데이터 자체는 정확함.

### 그럼 왜 사용자에게 `+` 가 사라진 것처럼 보이나

`ChampionStatsDetailPageClient` 의 `useState(initialTier || \"CHALLENGER\")` → `selectedTier === \"GRANDMASTER \"` (trailing space).

`ChampionStatsFilters` dropdown (`src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx:65`):

```tsx
{TIER_OPTIONS.find((o) => o.value === selectedTier)?.label ?? selectedTier}
```

`TIER_OPTIONS` 의 value 는 `\"GRANDMASTER+\"` 인데 들어온 값은 `\"GRANDMASTER \"` (trailing space). 매칭 실패하여 fallback 으로 `selectedTier` 그대로 표시 → 공백은 시각적으로 렌더링 안 됨 → 사용자에겐 \"그랜드마스터+\" 가 아닌 \"GRANDMASTER\" 로 보여 `+` 가 사라진 것으로 인식.

## Fix

두 Link href 의 `tier` value 를 `encodeURIComponent` 로 감싸 `+` → `%2B` 안전 인코딩.

```diff
- href={`/champion-stats/${id}?tier=${tier}&patch=${patch}&platformId=${platformId}`}
+ href={`/champion-stats/${id}?tier=${encodeURIComponent(tier)}&patch=${patch}&platformId=${platformId}`}
```

흐름:
1. Link href: `/champion-stats/AAA?tier=GRANDMASTER%2B&...`
2. detail server component: `searchParams.tier === \"GRANDMASTER+\"` (`%2B` 디코딩으로 `+` 복원)
3. client useState `selectedTier === \"GRANDMASTER+\"` → `TIER_OPTIONS.find(o => o.value === \"GRANDMASTER+\")` 매칭 성공 → 라벨 \"그랜드마스터+\" 정상 표시
4. axios `params: { tier: \"GRANDMASTER+\" }` → server: `@RequestParam tier=\"GRANDMASTER+\"` → TierFilter GRANDMASTER+ ✅

영향 범위: `TIER_OPTIONS` 의 모든 plus 변형 (CHALLENGER 제외 — `+` 없음, GRANDMASTER+, MASTER+, DIAMOND+, EMERALD+, PLATINUM+, GOLD+, SILVER+, BRONZE+, IRON+) 모두 동일 fix 로 보존됨. patch / platformId 는 현 query 값 (예: \"15.21\", \"kr\") 이 ASCII 단순 문자라 인코딩 영향 없어 surgical 차원에서 건드리지 않음.

`patch` / `platformId` 가 미래에 `+` 또는 공백을 가질 가능성이 생기면 같은 인코딩 적용이 필요하지만 본 PR 의 직접 trace 범위 밖이라 보존.

## 대체 검증

- **수동 시나리오** (worker 환경에서 dev server + backend 의존성을 함께 띄울 수 없어 자동 e2e 불가):
  1. `pnpm dev` 후 `/champion-stats` 진입.
  2. 티어 dropdown 에서 \"그랜드마스터+\" 선택.
  3. 좌측 사이드바 또는 우측 테이블에서 챔피언 클릭.
  4. **기대**: detail 페이지 URL 이 `?tier=GRANDMASTER%2B&...` (DevTools URL bar 확인) 이고, 상단 티어 필터 dropdown 이 \"그랜드마스터+\" 로 표시되며, server 응답이 GRANDMASTER+ 범위 데이터.
  5. master+, challenger+ (TIER_OPTIONS 의 다른 plus 변형) 도 동일 절차로 검증.

- **단위/통합 테스트 커버 범위**: 본 레포에 jest / vitest 등 unit test framework 미설치 — `package.json` 의 `scripts` 에 test 명령 없음. Playwright 설정은 있으나 `tests/` 디렉토리 비어 있음.

- **E2E 자동화 불가 사유**: 회귀 보장을 위한 e2e 추가는 Playwright + backend (lol-server) + 데이터 fixture 동시 띄우는 인프라가 필요해 현 PR scope (surgical 2 라인 fix) 와 균형이 안 맞음. 회귀 테스트 인프라 도입은 별도 이슈에서 다룰 사안.

- **정적 검증**:
  - `npx tsc --noEmit` → 0 errors.
  - `pnpm lint` → 0 errors, 5 warnings (전부 변경분 무관 기존 코드).

## 변경 라인

- `src/widgets/champion-stats-panel/ui/ChampionListSidebar.tsx`: 1 line
- `src/widgets/champion-stats-panel/ui/ChampionStatsTable.tsx`: 1 line

🤖 Generated by Padosol