### PR TITLE
refactor: 불필요한 useState/useEffect 제거 (Vercel best practices)

### DIFF
--- a/src/entities/champion/index.ts
+++ b/src/entities/champion/index.ts
@@ -4,6 +4,7 @@ export { getChampionPositionStats } from "./api/championPositionStatsApi";
 export { useChampionRotate } from "./model/useChampionRotate";
 export { useChampionStats } from "./model/useChampionStats";
 export { useChampionPositionStats } from "./model/useChampionPositionStats";
+export { useChampionById, useChampionsByIds } from "./model/useChampion";
 export { getChampionById, getChampionsByIds, getChampionImageUrl, getChampionNameByEnglishName } from "./lib/championImage";
 export { WIN_RATE_COLOR_CLASSES, getWinRateTextClass, calcWinRateCeil2 } from "./lib/championStatsUtils";
 export { getTierBadgeClass } from "./lib/tierBadge";

--- a/src/entities/champion/model/useChampion.ts
+++ b/src/entities/champion/model/useChampion.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+import {
+  useGameDataStore,
+  type ChampionData,
+} from "@/shared/model/game-data";
+
+export function useChampionById(championId: number): ChampionData | null {
+  const championData = useGameDataStore((s) => s.championData);
+
+  return useMemo(() => {
+    if (!championData) {
+      return null;
+    }
+    const champion = Object.values(championData.data).find(
+      (c) => c.key === String(championId)
+    );
+    return champion || null;
+  }, [championData, championId]);
+}
+
+export function useChampionsByIds(championIds: number[]): ChampionData[] {
+  const championData = useGameDataStore((s) => s.championData);
+  const idsKey = championIds.join(",");
+
+  return useMemo(() => {
+    if (!championData) {
+      return [];
+    }
+    const idSet = new Set(idsKey ? idsKey.split(",") : []);
+    return Object.values(championData.data).filter((c) => idSet.has(c.key));
+  }, [championData, idsKey]);
+}

--- a/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
+++ b/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
@@ -3,7 +3,8 @@
 import { AVAILABLE_REGIONS } from "@/features/region-select";
 import { useSeasonStore } from "@/entities/season";
 import { ChevronDown } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
+import { useClickOutside } from "@/shared/lib/useClickOutside";
 import { TIER_OPTIONS } from "../lib/tiers";
 
 interface ChampionStatsFiltersProps {
@@ -34,22 +35,9 @@ export default function ChampionStatsFilters({
   const latestPatches = latestSeason?.patchVersions ?? [];
   const activePatch = selectedPatch || latestPatches[0] || "";
 
-  const handleClickOutside = useCallback((e: MouseEvent) => {
-    if (tierRef.current && !tierRef.current.contains(e.target as Node)) {
-      setTierOpen(false);
-    }
-    if (patchRef.current && !patchRef.current.contains(e.target as Node)) {
-      setPatchOpen(false);
-    }
-    if (platformRef.current && !platformRef.current.contains(e.target as Node)) {
-      setPlatformOpen(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [handleClickOutside]);
+  useClickOutside(tierRef, () => setTierOpen(false), tierOpen);
+  useClickOutside(patchRef, () => setPatchOpen(false), patchOpen);
+  useClickOutside(platformRef, () => setPlatformOpen(false), platformOpen);
 
   return (
     <div className="grid grid-cols-3 gap-2 sm:flex sm:items-center sm:justify-center sm:flex-wrap">

--- a/src/features/ranking-filter/ui/RankingFilters.tsx
+++ b/src/features/ranking-filter/ui/RankingFilters.tsx
@@ -3,9 +3,10 @@
 import { useTierCutoffs } from "@/entities/ranking";
 import { AVAILABLE_REGIONS, type RegionValue } from "@/features/region-select";
 import { getTierImageUrl } from "@/shared/lib/tier";
+import { useClickOutside } from "@/shared/lib/useClickOutside";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 interface RankingFiltersProps {
   region: RegionValue;
@@ -64,27 +65,8 @@ export default function RankingFilters({
   const regionRef = useRef<HTMLDivElement>(null);
   const queueTypeRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        regionRef.current &&
-        !regionRef.current.contains(event.target as Node)
-      ) {
-        setIsRegionOpen(false);
-      }
-      if (
-        queueTypeRef.current &&
-        !queueTypeRef.current.contains(event.target as Node)
-      ) {
-        setIsQueueTypeOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
+  useClickOutside(regionRef, () => setIsRegionOpen(false), isRegionOpen);
+  useClickOutside(queueTypeRef, () => setIsQueueTypeOpen(false), isQueueTypeOpen);
 
   const selectedRegion = AVAILABLE_REGIONS.find((r) => r.value === region);
   const selectedQueueTypeLabel =

--- a/src/features/summoner-search/model/useSummonerSearch.ts
+++ b/src/features/summoner-search/model/useSummonerSearch.ts
@@ -20,8 +20,14 @@ export function useSummonerSearch() {
   const autocompleteRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const regionRef = useRef<HTMLDivElement>(null);
+  const justSelectedRef = useRef(false);
 
   useEffect(() => {
+    if (justSelectedRef.current) {
+      justSelectedRef.current = false;
+      return;
+    }
+
     const trimmedName = summonerName.trim();
 
     if (trimmedName.length < 2) {
@@ -92,6 +98,7 @@ export function useSummonerSearch() {
     const encodedName = encodeURIComponent(gameName);
     router.push(`/summoners/${region}/${encodedName}`);
     setShowAutocomplete(false);
+    justSelectedRef.current = true;
     setSummonerName(gameName);
   };
 

--- a/src/shared/lib/useClickOutside.ts
+++ b/src/shared/lib/useClickOutside.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export function useClickOutside<T extends HTMLElement>(
+  ref: React.RefObject<T | null>,
+  handler: () => void,
+  enabled: boolean = true,
+): void {
+  const handlerRef = useRef(handler);
+  useEffect(() => {
+    handlerRef.current = handler;
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handlerRef.current();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [ref, enabled]);
+}

--- a/src/shared/ui/game/SpellRuneImages.tsx
+++ b/src/shared/ui/game/SpellRuneImages.tsx
@@ -1,22 +1,21 @@
 "use client";
 
-import { getSpellImageUrlAsync } from "@/shared/lib/game";
+import { getSpellImageUrl } from "@/shared/lib/game";
+import { useGameDataStore } from "@/shared/model/game-data";
 import { GameTooltip } from "@/shared/ui/tooltip";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
 // 소환사 주문 이미지 컴포넌트 (비동기 로드)
 export function SummonerSpellImage({ spellId, small, size }: { spellId: number; small?: boolean; size?: "default" | "small" | "xs" | "2xs" }) {
-  const [imageUrl, setImageUrl] = useState<string>("");
+  const summonerData = useGameDataStore((s) => s.summonerData);
+  // summonerData를 의존성에 포함해 게임 데이터 hydration 시 URL을 재계산한다
+  // (getSpellImageUrl이 store를 getState로 읽어 lint가 의존성을 감지하지 못함)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const imageUrl = useMemo(() => getSpellImageUrl(spellId), [spellId, summonerData]);
   const resolvedSize = size ?? (small ? "small" : "default");
   const sizeClass = { "2xs": "w-3.5 h-3.5", xs: "w-[18px] h-[18px]", small: "w-6 h-6", default: "w-7 h-7" }[resolvedSize];
   const imgSize = { "2xs": 14, xs: 18, small: 24, default: 28 }[resolvedSize];
-
-  useEffect(() => {
-    if (spellId > 0) {
-      getSpellImageUrlAsync(spellId).then(setImageUrl).catch(() => { });
-    }
-  }, [spellId]);
 
   if (!imageUrl) {
     return null;

--- a/src/widgets/home-sections/ui/DesktopAppSection.tsx
+++ b/src/widgets/home-sections/ui/DesktopAppSection.tsx
@@ -1,41 +1,24 @@
 "use client";
 
-import { useChampionRotate, getChampionImageUrl, getChampionsByIds } from "@/entities/champion";
+import {
+  useChampionRotate,
+  getChampionImageUrl,
+  useChampionsByIds,
+} from "@/entities/champion";
 import Image from "next/image";
-import { useEffect, useState } from "react";
-
-interface ChampionData {
-  id: string;
-  key: string;
-  name: string;
-  title: string;
-  image: {
-    full: string;
-  };
-}
 
 export default function DesktopAppSection() {
   const { data: rotationData, isLoading } = useChampionRotate("kr");
-  const [champions, setChampions] = useState<ChampionData[]>([]);
-  const [hasLoadedChampions, setHasLoadedChampions] = useState(false);
+  const champions = useChampionsByIds(rotationData?.freeChampionIds ?? []);
 
-  useEffect(() => {
-    if (
-      rotationData?.freeChampionIds &&
-      rotationData.freeChampionIds.length > 0
-    ) {
-      getChampionsByIds(rotationData.freeChampionIds)
-        .then(setChampions)
-        .finally(() => setHasLoadedChampions(true));
-    }
-  }, [rotationData]);
+  const hasFreeChampions =
+    !!rotationData?.freeChampionIds &&
+    rotationData.freeChampionIds.length > 0;
 
-  // rotationData가 있고 아직 로드 완료되지 않았으면 로딩 중
+  // rotation 쿼리가 로딩 중이거나, 무료 챔피언 ID는 있는데
+  // 아직 챔피언 데이터가 파생되지 않았으면 로딩 중
   const isChampionsLoading =
-    !isLoading &&
-    rotationData?.freeChampionIds &&
-    rotationData.freeChampionIds.length > 0 &&
-    !hasLoadedChampions;
+    !isLoading && hasFreeChampions && champions.length === 0;
 
   return (
     <div>

--- a/src/widgets/ingame/ui/BannedChampions.tsx
+++ b/src/widgets/ingame/ui/BannedChampions.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import type { SpectatorBannedChampion } from "@/entities/spectator";
-import { getChampionById } from "@/entities/champion";
+import { useChampionsByIds } from "@/entities/champion";
 import { getChampionImageUrl } from "@/entities/champion";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
 interface BannedChampionsProps {
   bannedChampions: SpectatorBannedChampion[];
@@ -22,30 +22,39 @@ export default function BannedChampions({
   bannedChampions,
   align = "left",
 }: BannedChampionsProps) {
-  const [bannedInfo, setBannedInfo] = useState<BannedChampionInfo[]>([]);
+  const championIds = useMemo(
+    () =>
+      bannedChampions
+        .filter((ban) => ban.championId !== -1)
+        .map((ban) => ban.championId),
+    [bannedChampions]
+  );
+  const champions = useChampionsByIds(championIds);
 
-  useEffect(() => {
-    const loadBannedChampions = async () => {
-      const info = await Promise.all(
-        bannedChampions.map(async (ban) => {
-          if (ban.championId === -1) {
-            return {
-              ...ban,
-              championName: undefined,
-            };
-          }
-          const champion = await getChampionById(ban.championId);
-          return {
-            ...ban,
-            championName: champion?.id, // id 필드 사용 (영문 이름)
-          };
-        })
-      );
-      setBannedInfo(info.sort((a, b) => a.pickTurn - b.pickTurn));
-    };
+  const championByKey = useMemo(() => {
+    const map = new Map<string, (typeof champions)[number]>();
+    for (const champion of champions) {
+      map.set(champion.key, champion);
+    }
+    return map;
+  }, [champions]);
 
-    loadBannedChampions();
-  }, [bannedChampions]);
+  const bannedInfo = useMemo<BannedChampionInfo[]>(() => {
+    const info = bannedChampions.map((ban) => {
+      if (ban.championId === -1) {
+        return {
+          ...ban,
+          championName: undefined,
+        };
+      }
+      const champion = championByKey.get(String(ban.championId));
+      return {
+        ...ban,
+        championName: champion?.id, // id 필드 사용 (영문 이름)
+      };
+    });
+    return info.sort((a, b) => a.pickTurn - b.pickTurn);
+  }, [bannedChampions, championByKey]);
 
   return (
     <div

--- a/src/widgets/ingame/ui/IngamePlayer.tsx
+++ b/src/widgets/ingame/ui/IngamePlayer.tsx
@@ -2,10 +2,11 @@
 
 import { GameTooltip } from "@/shared/ui/tooltip";
 import type { SpectatorParticipant } from "@/entities/spectator";
-import { getChampionById, getChampionImageUrl } from "@/entities/champion";
-import { getPerkImageUrl, getSpellImageUrlAsync } from "@/shared/lib/game";
+import { getChampionImageUrl, useChampionById } from "@/entities/champion";
+import { getPerkImageUrl, getSpellImageUrl } from "@/shared/lib/game";
+import { useGameDataStore } from "@/shared/model/game-data";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
 interface IngamePlayerProps {
   participant: SpectatorParticipant;
@@ -14,35 +15,16 @@ interface IngamePlayerProps {
 export default function IngamePlayer({
   participant,
 }: IngamePlayerProps) {
-  const [champId, setChampId] = useState<string>("");
-  const [champName, setChampName] = useState<string>("");
-  const [spell1Url, setSpell1Url] = useState<string>("");
-  const [spell2Url, setSpell2Url] = useState<string>("");
+  const champion = useChampionById(participant.championId);
+  const champId = champion?.id ?? ""; // 이미지 URL용 (영문 이름)
+  const champName = champion?.name ?? ""; // 표시용 (한글 이름)
 
-  useEffect(() => {
-    const loadChampion = async () => {
-      const champion = await getChampionById(participant.championId);
-      if (champion) {
-        setChampId(champion.id); // 이미지 URL용 (영문 이름)
-        setChampName(champion.name); // 표시용 (한글 이름)
-      }
-    };
-    loadChampion();
-  }, [participant.championId]);
-
-  useEffect(() => {
-    const loadSpellUrls = async () => {
-      if (participant.spell1Id > 0) {
-        const url = await getSpellImageUrlAsync(participant.spell1Id);
-        setSpell1Url(url);
-      }
-      if (participant.spell2Id > 0) {
-        const url = await getSpellImageUrlAsync(participant.spell2Id);
-        setSpell2Url(url);
-      }
-    };
-    loadSpellUrls();
-  }, [participant.spell1Id, participant.spell2Id]);
+  // getSpellImageUrl은 store.getState() 간접참조라 비반응형 → summonerData 구독으로 hydration 갱신
+  const summonerData = useGameDataStore((s) => s.summonerData);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const spell1Url = useMemo(() => getSpellImageUrl(participant.spell1Id), [participant.spell1Id, summonerData]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const spell2Url = useMemo(() => getSpellImageUrl(participant.spell2Id), [participant.spell2Id, summonerData]);
 
   const championImageUrl = champId
     ? getChampionImageUrl(champId)

--- a/src/widgets/summoner-profile/ui/ChampionStats.tsx
+++ b/src/widgets/summoner-profile/ui/ChampionStats.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { useChampionRanking } from "@/entities/match";
-import { useGameDataStore } from "@/shared/model/game-data";
 import { GameTooltip } from "@/shared/ui/tooltip";
 import {
   getChampionImageUrl,
 } from "@/entities/champion";
 import Image from "next/image";
 import { useSeasonStore } from "@/entities/season";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 interface ChampionStatsProps {
   puuid?: string | null;
@@ -38,12 +37,6 @@ export default function ChampionStats({
 
   const [sortField, setSortField] = useState<SortField>("playCount");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
-
-  // champion.json 데이터 로드
-  const loadChampionData = useGameDataStore((state) => state.loadChampionData);
-  useEffect(() => {
-    loadChampionData();
-  }, [loadChampionData]);
 
   // limit이 있으면 제한
   const displayedStats = limit ? championStats.slice(0, limit) : championStats;

--- a/src/widgets/summoner-profile/ui/ChampionStatsOverview.tsx
+++ b/src/widgets/summoner-profile/ui/ChampionStatsOverview.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { useChampionRanking } from "@/entities/match";
-import { useGameDataStore } from "@/shared/model/game-data";
 import { GameTooltip } from "@/shared/ui/tooltip";
 import { getChampionImageUrl, getChampionNameByEnglishName } from "@/entities/champion";
 import { calcWinRateCeil2, getWinRateTextClass } from "@/entities/champion";
 import { getKDAColorClass } from "@/shared/lib/game";
 import { useSeasonStore } from "@/entities/season";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 type QueueTabType = "solo" | "flex";
 
@@ -41,12 +40,6 @@ export default function ChampionStatsOverview({
   );
 
   const championStats = data?.[activeQueue] ?? [];
-
-  // champion.json 데이터 로드 (zustand store 사용)
-  const loadChampionData = useGameDataStore((state) => state.loadChampionData);
-  useEffect(() => {
-    loadChampionData();
-  }, [loadChampionData]);
 
   // limit이 있으면 제한
   const displayedStats = limit ? championStats.slice(0, limit) : championStats;

--- a/src/widgets/summoner-profile/ui/ProfileSection.tsx
+++ b/src/widgets/summoner-profile/ui/ProfileSection.tsx
@@ -12,7 +12,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { RefreshCw } from "lucide-react";
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 interface ProfileSectionProps {
   summonerName: string; // gameName 형식: "name-tagLine"
@@ -45,12 +45,8 @@ export default function ProfileSection({
   const [isPolling, setIsPolling] = useState(false);
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const pollingStartTimeRef = useRef<number | null>(null);
-  const [cooldownInfo, setCooldownInfo] = useState<{
-    remainingSeconds: number;
-  } | null>(null);
   const [refreshError, setRefreshError] = useState<string | null>(null);
-  const [elapsedText, setElapsedText] = useState<string | null>(null);
-  const [cooldownReady, setCooldownReady] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
 
   // 컴포넌트 언마운트 시 폴링 정리
   useEffect(() => {
@@ -63,50 +59,48 @@ export default function ProfileSection({
   }, []);
 
   // 쿨다운 (2분) 계산 - 서버의 lastRevisionDateTime 기준
+  // lastRevisionClickDateTime이 있을 때만 1초마다 now를 갱신해 재계산을 트리거한다.
   useEffect(() => {
-    const updateCooldownInfo = () => {
-      if (!profileData?.lastRevisionClickDateTime) {
-        setCooldownInfo(null);
-        setElapsedText(null);
-        if (!cooldownReady) setCooldownReady(true);
-        return;
-      }
-
-      const raw = profileData.lastRevisionClickDateTime;
-      const lastRevisionTime = dayjs(raw.replace(' ', 'T') + '+09:00').valueOf();
-      const elapsed = Date.now() - lastRevisionTime;
-      const remaining = Math.max(0, 120000 - elapsed);
-
-      if (remaining > 0) {
-        setCooldownInfo({ remainingSeconds: Math.ceil(remaining / 1000) });
-      } else {
-        setCooldownInfo(null);
-      }
-
-      // 상대 시간 텍스트 계산
-      const elapsedMinutes = Math.floor(elapsed / 60000);
-      const elapsedHours = Math.floor(elapsed / 3600000);
-      const elapsedDays = Math.floor(elapsed / 86400000);
-
-      let timeText: string;
-      if (elapsedMinutes < 1) {
-        timeText = '1분 미만';
-      } else if (elapsedMinutes < 60) {
-        timeText = `${elapsedMinutes}분 전`;
-      } else if (elapsedHours < 24) {
-        timeText = `${elapsedHours}시간 전`;
-      } else {
-        timeText = `${elapsedDays}일 전`;
-      }
-
-      setElapsedText(timeText);
-      if (!cooldownReady) setCooldownReady(true);
-    };
-
-    updateCooldownInfo();
-    const interval = setInterval(updateCooldownInfo, 1000);
+    if (!profileData?.lastRevisionClickDateTime) return;
+    const interval = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(interval);
-  }, [profileData?.lastRevisionClickDateTime, cooldownReady]);
+  }, [profileData?.lastRevisionClickDateTime]);
+
+  // now + lastRevisionClickDateTime 기준으로 렌더 중 파생값 계산
+  const { cooldownInfo, elapsedText } = useMemo<{
+    cooldownInfo: { remainingSeconds: number } | null;
+    elapsedText: string | null;
+  }>(() => {
+    if (!profileData?.lastRevisionClickDateTime) {
+      return { cooldownInfo: null, elapsedText: null };
+    }
+
+    const raw = profileData.lastRevisionClickDateTime;
+    const lastRevisionTime = dayjs(raw.replace(' ', 'T') + '+09:00').valueOf();
+    const elapsed = now - lastRevisionTime;
+    const remaining = Math.max(0, 120000 - elapsed);
+
+    const cooldownInfo =
+      remaining > 0 ? { remainingSeconds: Math.ceil(remaining / 1000) } : null;
+
+    // 상대 시간 텍스트 계산
+    const elapsedMinutes = Math.floor(elapsed / 60000);
+    const elapsedHours = Math.floor(elapsed / 3600000);
+    const elapsedDays = Math.floor(elapsed / 86400000);
+
+    let elapsedText: string;
+    if (elapsedMinutes < 1) {
+      elapsedText = '1분 미만';
+    } else if (elapsedMinutes < 60) {
+      elapsedText = `${elapsedMinutes}분 전`;
+    } else if (elapsedHours < 24) {
+      elapsedText = `${elapsedHours}시간 전`;
+    } else {
+      elapsedText = `${elapsedDays}일 전`;
+    }
+
+    return { cooldownInfo, elapsedText };
+  }, [profileData?.lastRevisionClickDateTime, now]);
 
   // 에러 메시지 5초 후 자동 소멸
   useEffect(() => {
@@ -117,7 +111,6 @@ export default function ProfileSection({
 
   // 갱신 버튼 비활성화 여부 확인
   const isRefreshDisabled = () => {
-    if (!cooldownReady) return true;
     if (isRefreshing || isPolling) return true;
     if (cooldownInfo !== null) return true;
     return false;


### PR DESCRIPTION
## 요약
Vercel React best practices 기준으로 불필요한 `useState`/`useEffect`를 제거합니다. 핵심은 `GameDataLoader`가 앱 시작 시 store에 프리로드하는 데이터를 비동기 effect로 다시 state에 복사하던 안티패턴(You Might Not Need an Effect)을 **store 구독 기반 렌더 중 동기 파생**으로 전환한 것입니다.

## 변경 내용
### 신규 모듈
- `entities/champion/model/useChampion.ts` — `useChampionById`/`useChampionsByIds` (store 구독 동기 셀렉터, hydration 시 자동 갱신)
- `shared/lib/useClickOutside.ts` — 외부 클릭 감지 공용 훅

### 비동기 effect → 동기 파생
- `SpellRuneImages` — spellId→URL 비동기 effect 제거
- `IngamePlayer` — 챔피언/스펠 state 4개 + effect 2개 제거
- `BannedChampions` — 매핑/정렬 effect 제거 (순서·필드 보존)
- `DesktopAppSection` — `champions`/`hasLoadedChampions` state + effect 제거

### 불필요/중복 제거
- `ChampionStatsOverview`/`ChampionStats` — `GameDataLoader`와 중복된 `loadChampionData` effect 제거
- `ProfileSection` — 쿨다운 파생 state 3개 → 단일 tick state, 불필요한 `cooldownReady` deps 제거

### 외부클릭/이벤트
- `ChampionStatsFilters`(×3)/`RankingFilters`(×2) — 외부클릭 effect를 `useClickOutside`로 통합
- `useSummonerSearch` — 자동완성 선택 후 디바운스 재검색 방지 가드

## 의도적 미변경 (회귀 위험)
- **Tooltip** `positioned` effect — post-commit DOM 측정에 필수(이벤트화 시 툴팁 비가시화). 유지.
- **useSummonerSearch 외부클릭** — 3-ref AND 로직이라 단일 ref 훅으로 의미 보존 불가. 유지.
- **MatchHistory → useInfiniteQuery** — 고위험·데이터 페칭 구조 전면 변경이라 별도 PR로 분리 예정.

## 검증
- `tsc --noEmit` 통과
- `eslint` (변경 파일) 통과
- `next build` (프로덕션) 통과 — 정적 페이지 18/18 생성
- 코드량: 11파일 순 -70줄 + 신규 훅 2개

## 동작 변화 참고
- ProfileSection: 기존엔 마운트 직후 1프레임 동안 새로고침 버튼이 잠깐 disabled였으나, 이제 첫 렌더부터 올바른 상태입니다(개선, 표시 결과 회귀 아님).
