### PR TITLE
feat: 듀오 API 전체 연동 (match-result·SSE 실시간 알림·CLOSED 상태)

### DIFF
--- a/src/entities/duo/api/duoRequestApi.ts
+++ b/src/entities/duo/api/duoRequestApi.ts
@@ -36,6 +36,16 @@ export async function confirmDuoRequest(
   return response.data.data;
 }
 
+/** 매칭 결과 조회 — 매칭 당사자(소유자 ↔ 확정 요청자)만 호출 가능, 파트너 게임명/태그 반환 */
+export async function getDuoMatchResult(
+  postId: number,
+): Promise<MatchActionResponse> {
+  const response = await apiClient.get<ApiResponse<MatchActionResponse>>(
+    `/duo/posts/${postId}/match-result`,
+  );
+  return response.data.data;
+}
+
 export async function rejectDuoRequest(requestId: number): Promise<void> {
   await apiClient.put(`/duo/requests/${requestId}/reject`);
 }

--- a/src/entities/duo/index.ts
+++ b/src/entities/duo/index.ts
@@ -41,6 +41,7 @@ export {
   getPostRequests,
   acceptDuoRequest,
   confirmDuoRequest,
+  getDuoMatchResult,
   rejectDuoRequest,
   cancelDuoRequest,
   getMyDuoRequests,
@@ -49,6 +50,8 @@ export {
 // Hooks
 export { useDuoPosts, useMyDuoPosts, duoKeys } from "./model/useDuoPosts";
 export { useDuoPostDetail } from "./model/useDuoPostDetail";
+export { useDuoMatchResult } from "./model/useDuoMatchResult";
+export { useDuoNotifications } from "./model/useDuoNotifications";
 export {
   useCreateDuoPost,
   useUpdateDuoPost,

--- a/src/entities/duo/model/useDuoMatchResult.ts
+++ b/src/entities/duo/model/useDuoMatchResult.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { getDuoMatchResult } from "../api/duoRequestApi";
+import type { MatchActionResponse } from "../types";
+import { duoKeys } from "./useDuoPosts";
+
+/**
+ * 매칭 결과(파트너 정보) 조회. 매칭 당사자가 아닐 때 호출하면 403 이므로
+ * 소유자의 MATCHED 게시글 / 요청자의 CONFIRMED 요청에서만 `enabled` 로 켠다.
+ */
+export function useDuoMatchResult(postId: number, enabled: boolean) {
+  return useQuery<MatchActionResponse, Error>({
+    queryKey: duoKeys.matchResult(postId),
+    queryFn: () => getDuoMatchResult(postId),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/entities/duo/model/useDuoMatchResult.ts
+++ b/src/entities/duo/model/useDuoMatchResult.ts
@@ -13,5 +13,7 @@ export function useDuoMatchResult(postId: number, enabled: boolean) {
     queryFn: () => getDuoMatchResult(postId),
     enabled,
     staleTime: 5 * 60 * 1000,
+    // 비당사자는 403이 정상 응답이므로 글로벌 retry(1회)를 끈다
+    retry: false,
   });
 }

--- a/src/entities/duo/model/useDuoNotifications.ts
+++ b/src/entities/duo/model/useDuoNotifications.ts
@@ -29,11 +29,21 @@ export function useDuoNotifications(enabled: boolean) {
       queryClient.invalidateQueries({ queryKey: duoKeys.all });
     };
 
+    // 쿠키 인증이라 토큰 만료 시 EventSource 는 스스로 401→refresh 를 못 한다.
+    // 연속 오류가 임계치를 넘으면 재연결 폭주를 막기 위해 구독을 끊는다.
+    // (이후 갱신은 staleTime/페이지 재진입 시 일반 refetch 로 복구)
+    let consecutiveErrors = 0;
+    const MAX_CONSECUTIVE_ERRORS = 5;
+
     source.addEventListener("duo-notification", handleNotification);
+    source.onopen = () => {
+      consecutiveErrors = 0;
+    };
     source.onerror = () => {
-      // EventSource 는 기본적으로 자동 재연결한다. 닫힌 경우만 로깅.
-      if (source.readyState === EventSource.CLOSED) {
-        logger.warn("Duo SSE connection closed");
+      consecutiveErrors += 1;
+      if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+        logger.warn("Duo SSE 연속 오류로 구독 종료 — 새로고침 시 재연결");
+        source.close();
       }
     };
 

--- a/src/entities/duo/model/useDuoNotifications.ts
+++ b/src/entities/duo/model/useDuoNotifications.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { logger } from "@/shared/lib/logger";
+import { duoKeys } from "./useDuoPosts";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8100/api";
+
+/**
+ * 듀오 실시간 알림(SSE) 구독. 수신 이벤트(`duo-notification`: REQUEST_ACCEPTED /
+ * MATCH_CONFIRMED / REQUEST_CLOSED)마다 듀오 쿼리를 무효화해 목록·상세·내 요청을
+ * 자동 갱신한다. 쿠키 인증이므로 로그인 상태(`enabled`)에서만 연결한다.
+ * 멤버당 1연결 — 재구독 시 서버가 기존 연결을 종료한다.
+ */
+export function useDuoNotifications(enabled: boolean) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const source = new EventSource(
+      `${API_BASE_URL}/duo/notifications/subscribe`,
+      { withCredentials: true },
+    );
+
+    const handleNotification = () => {
+      queryClient.invalidateQueries({ queryKey: duoKeys.all });
+    };
+
+    source.addEventListener("duo-notification", handleNotification);
+    source.onerror = () => {
+      // EventSource 는 기본적으로 자동 재연결한다. 닫힌 경우만 로깅.
+      if (source.readyState === EventSource.CLOSED) {
+        logger.warn("Duo SSE connection closed");
+      }
+    };
+
+    return () => {
+      source.removeEventListener("duo-notification", handleNotification);
+      source.close();
+    };
+  }, [enabled, queryClient]);
+}

--- a/src/entities/duo/model/useDuoPosts.ts
+++ b/src/entities/duo/model/useDuoPosts.ts
@@ -8,6 +8,8 @@ export const duoKeys = {
   postList: (params: Omit<DuoPostFilters, "page">) =>
     [...duoKeys.posts(), params] as const,
   postDetail: (id: number) => [...duoKeys.posts(), "detail", id] as const,
+  matchResult: (postId: number) =>
+    [...duoKeys.posts(), "match-result", postId] as const,
   myPosts: () => [...duoKeys.all, "my-posts"] as const,
   myRequests: () => [...duoKeys.all, "my-requests"] as const,
 };

--- a/src/entities/duo/types.ts
+++ b/src/entities/duo/types.ts
@@ -1,6 +1,12 @@
 // === Lane ===
+/** 폼·필터에서 선택 가능한 라인 (서버 Lane enum 중 듀오에서 노출하는 5종) */
 export const LANES = ["TOP", "JUNGLE", "MID", "ADC", "SUPPORT"] as const;
-export type Lane = (typeof LANES)[number];
+/**
+ * 응답에 담길 수 있는 라인 값. 서버 Lane enum 은 FILL 을 포함하므로
+ * 타입을 넓혀 LANE_LABELS / LANE_IMAGE_KEY lookup 을 total 로 유지한다
+ * (선택 UI 에는 LANES 만 노출).
+ */
+export type Lane = (typeof LANES)[number] | "FILL";
 
 export const LANE_LABELS: Record<Lane, string> = {
   TOP: "탑",
@@ -8,6 +14,7 @@ export const LANE_LABELS: Record<Lane, string> = {
   MID: "미드",
   ADC: "원딜",
   SUPPORT: "서포터",
+  FILL: "상관없음",
 };
 
 /** Lane → 포지션 이미지 파일 키 (MID→MIDDLE, ADC→BOTTOM, SUPPORT→UTILITY) */
@@ -17,6 +24,7 @@ export const LANE_IMAGE_KEY: Record<Lane, string> = {
   MID: "MIDDLE",
   ADC: "BOTTOM",
   SUPPORT: "UTILITY",
+  FILL: "FILL",
 };
 
 // === Tier ===
@@ -41,7 +49,8 @@ export type RequestStatus =
   | "ACCEPTED"
   | "CONFIRMED"
   | "REJECTED"
-  | "CANCELLED";
+  | "CANCELLED"
+  | "CLOSED";
 
 export const POST_STATUS_LABELS: Record<PostStatus, string> = {
   ACTIVE: "모집 중",
@@ -56,6 +65,7 @@ export const REQUEST_STATUS_LABELS: Record<RequestStatus, string> = {
   CONFIRMED: "확정됨",
   REJECTED: "거절됨",
   CANCELLED: "취소됨",
+  CLOSED: "종료됨",
 };
 
 // === 챔피언 통계 ===

--- a/src/entities/duo/types.ts
+++ b/src/entities/duo/types.ts
@@ -1,12 +1,6 @@
 // === Lane ===
-/** 폼·필터에서 선택 가능한 라인 (서버 Lane enum 중 듀오에서 노출하는 5종) */
 export const LANES = ["TOP", "JUNGLE", "MID", "ADC", "SUPPORT"] as const;
-/**
- * 응답에 담길 수 있는 라인 값. 서버 Lane enum 은 FILL 을 포함하므로
- * 타입을 넓혀 LANE_LABELS / LANE_IMAGE_KEY lookup 을 total 로 유지한다
- * (선택 UI 에는 LANES 만 노출).
- */
-export type Lane = (typeof LANES)[number] | "FILL";
+export type Lane = (typeof LANES)[number];
 
 export const LANE_LABELS: Record<Lane, string> = {
   TOP: "탑",
@@ -14,7 +8,6 @@ export const LANE_LABELS: Record<Lane, string> = {
   MID: "미드",
   ADC: "원딜",
   SUPPORT: "서포터",
-  FILL: "상관없음",
 };
 
 /** Lane → 포지션 이미지 파일 키 (MID→MIDDLE, ADC→BOTTOM, SUPPORT→UTILITY) */
@@ -24,7 +17,6 @@ export const LANE_IMAGE_KEY: Record<Lane, string> = {
   MID: "MIDDLE",
   ADC: "BOTTOM",
   SUPPORT: "UTILITY",
-  FILL: "FILL",
 };
 
 // === Tier ===

--- a/src/widgets/duo-list/ui/DuoListPanel.tsx
+++ b/src/widgets/duo-list/ui/DuoListPanel.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import { Plus } from "lucide-react";
 import { useAuthStore } from "@/entities/auth";
-import { useDuoPosts } from "@/entities/duo";
+import { useDuoPosts, useDuoNotifications } from "@/entities/duo";
 import type { Lane, Tier, DuoPostFilters } from "@/entities/duo";
 import { DuoFilters } from "@/features/duo-filter";
 import { DuoRegisterModal } from "@/features/duo-register";
@@ -16,6 +16,9 @@ type DuoTab = "posts" | "my-posts" | "my-requests";
 
 export default function DuoListPanel() {
   const user = useAuthStore((s) => s.user);
+
+  // 듀오 페이지 체류 중 실시간 알림 구독 → 수신 시 듀오 쿼리 자동 갱신
+  useDuoNotifications(!!user);
 
   const [activeTab, setActiveTab] = useState<DuoTab>("posts");
   const [selectedPostId, setSelectedPostId] = useState<number | null>(null);

--- a/src/widgets/duo-list/ui/DuoPostDetailModal.tsx
+++ b/src/widgets/duo-list/ui/DuoPostDetailModal.tsx
@@ -18,6 +18,7 @@ import { getTierName } from "@/shared/lib/tier";
 import { getRelativeTime } from "@/shared/lib/date";
 import { RequestActionButtons } from "@/features/duo-matching";
 import { DuoRequestModal } from "@/features/duo-request";
+import PartnerName from "./PartnerName";
 
 interface DuoPostDetailModalProps {
   postId: number | null;
@@ -244,12 +245,10 @@ function OwnerSection({
       {post.status === "MATCHED" && partner?.partnerGameName && (
         <div className="bg-primary/10 border border-primary/30 rounded-md p-3 text-sm">
           <span className="text-on-surface-medium">매칭 완료 · 파트너 </span>
-          <span className="text-primary font-medium">
-            {partner.partnerGameName}
-            <span className="text-on-surface-disabled">
-              #{partner.partnerTagLine}
-            </span>
-          </span>
+          <PartnerName
+            gameName={partner.partnerGameName}
+            tagLine={partner.partnerTagLine}
+          />
         </div>
       )}
 

--- a/src/widgets/duo-list/ui/DuoPostDetailModal.tsx
+++ b/src/widgets/duo-list/ui/DuoPostDetailModal.tsx
@@ -6,6 +6,7 @@ import { X, Mic, MicOff, Trash2, Pencil } from "lucide-react";
 import {
   useDuoPostDetail,
   useDeleteDuoPost,
+  useDuoMatchResult,
   LANE_LABELS,
   LANE_IMAGE_KEY,
   REQUEST_STATUS_LABELS,
@@ -234,8 +235,24 @@ function OwnerSection({
   onDelete: () => void;
   isDeleting: boolean;
 }) {
+  const matchResult = useDuoMatchResult(post.id, post.status === "MATCHED");
+  const partner = matchResult.data;
+
   return (
     <div className="space-y-4 border-t border-divider pt-4">
+      {/* 매칭 완료 시 파트너 정보 */}
+      {post.status === "MATCHED" && partner?.partnerGameName && (
+        <div className="bg-primary/10 border border-primary/30 rounded-md p-3 text-sm">
+          <span className="text-on-surface-medium">매칭 완료 · 파트너 </span>
+          <span className="text-primary font-medium">
+            {partner.partnerGameName}
+            <span className="text-on-surface-disabled">
+              #{partner.partnerTagLine}
+            </span>
+          </span>
+        </div>
+      )}
+
       {/* 소유자 액션 */}
       {post.status === "ACTIVE" && (
         <div className="flex gap-2">

--- a/src/widgets/duo-list/ui/DuoRequestCard.tsx
+++ b/src/widgets/duo-list/ui/DuoRequestCard.tsx
@@ -7,6 +7,7 @@ import {
   LANE_LABELS,
   LANE_IMAGE_KEY,
   REQUEST_STATUS_LABELS,
+  useDuoMatchResult,
 } from "@/entities/duo";
 import { getPositionImageUrl } from "@/shared/lib/position";
 import { getTierName } from "@/shared/lib/tier";
@@ -23,14 +24,20 @@ const STATUS_COLORS: Record<string, string> = {
   CONFIRMED: "text-primary",
   REJECTED: "text-red-400",
   CANCELLED: "text-on-surface-disabled",
+  CLOSED: "text-on-surface-disabled",
 };
 
 export default function DuoRequestCard({ request }: DuoRequestCardProps) {
   const tier = request.tier;
   const isMasterPlus = tier !== null && ["MASTER", "GRANDMASTER", "CHALLENGER"].includes(tier);
 
+  const isConfirmed = request.status === "CONFIRMED";
+  const matchResult = useDuoMatchResult(request.duoPostId, isConfirmed);
+  const partner = matchResult.data;
+
   return (
-    <div className="bg-surface-1 border border-divider rounded-lg p-3 flex items-center gap-3">
+    <div className="bg-surface-1 border border-divider rounded-lg p-3">
+      <div className="flex items-center gap-3">
       {/* 라인 아이콘 */}
       <div className="flex items-center gap-1 shrink-0">
         <Image
@@ -93,6 +100,20 @@ export default function DuoRequestCard({ request }: DuoRequestCardProps) {
           status={request.status}
         />
       </div>
+      </div>
+
+      {/* 매칭 확정 시 파트너 정보 */}
+      {isConfirmed && partner?.partnerGameName && (
+        <div className="mt-2 pt-2 border-t border-divider flex items-center gap-1.5 text-xs">
+          <span className="text-on-surface-disabled">파트너</span>
+          <span className="text-primary font-medium">
+            {partner.partnerGameName}
+            <span className="text-on-surface-disabled">
+              #{partner.partnerTagLine}
+            </span>
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/widgets/duo-list/ui/DuoRequestCard.tsx
+++ b/src/widgets/duo-list/ui/DuoRequestCard.tsx
@@ -13,6 +13,7 @@ import { getPositionImageUrl } from "@/shared/lib/position";
 import { getTierName } from "@/shared/lib/tier";
 import { getRelativeTime } from "@/shared/lib/date";
 import { RequesterActionButtons } from "@/features/duo-matching";
+import PartnerName from "./PartnerName";
 
 interface DuoRequestCardProps {
   request: DuoRequest;
@@ -106,12 +107,10 @@ export default function DuoRequestCard({ request }: DuoRequestCardProps) {
       {isConfirmed && partner?.partnerGameName && (
         <div className="mt-2 pt-2 border-t border-divider flex items-center gap-1.5 text-xs">
           <span className="text-on-surface-disabled">파트너</span>
-          <span className="text-primary font-medium">
-            {partner.partnerGameName}
-            <span className="text-on-surface-disabled">
-              #{partner.partnerTagLine}
-            </span>
-          </span>
+          <PartnerName
+            gameName={partner.partnerGameName}
+            tagLine={partner.partnerTagLine}
+          />
         </div>
       )}
     </div>

--- a/src/widgets/duo-list/ui/PartnerName.tsx
+++ b/src/widgets/duo-list/ui/PartnerName.tsx
@@ -1,0 +1,16 @@
+interface PartnerNameProps {
+  gameName: string;
+  tagLine: string | null;
+}
+
+/** 매칭 파트너 게임명#태그라인 표시. tagLine 이 null 이면 '#' 없이 게임명만 렌더. */
+export default function PartnerName({ gameName, tagLine }: PartnerNameProps) {
+  return (
+    <span className="text-primary font-medium">
+      {gameName}
+      {tagLine && (
+        <span className="text-on-surface-disabled">#{tagLine}</span>
+      )}
+    </span>
+  );
+}

--- a/src/widgets/layout/ui/Header.tsx
+++ b/src/widgets/layout/ui/Header.tsx
@@ -3,8 +3,14 @@
 import Link from "next/link";
 import Image from "next/image";
 import { ThemeToggle } from "@/features/theme-toggle";
+import { useLogout } from "@/features/auth";
+import { useAuthStore } from "@/entities/auth";
+import { useHasHydrated } from "@/shared/lib/useHasHydrated";
 
 export default function Header() {
+  const user = useAuthStore((s) => s.user);
+  const hasHydrated = useHasHydrated(useAuthStore);
+  const { handleLogout } = useLogout();
 
   return (
     <header className="bg-surface-1 border-b border-divider">
@@ -25,6 +31,29 @@ export default function Header() {
             </div>
             <div className="flex items-center gap-4">
               <ThemeToggle />
+              {!hasHydrated ? null : user ? (
+                <>
+                  <Link
+                    href="/mypage"
+                    className="text-on-surface-medium hover:text-on-surface"
+                  >
+                    {user.nickname}
+                  </Link>
+                  <button
+                    onClick={handleLogout}
+                    className="text-on-surface-medium hover:text-on-surface"
+                  >
+                    로그아웃
+                  </button>
+                </>
+              ) : (
+                <Link
+                  href="/login"
+                  className="text-on-surface-medium hover:text-on-surface"
+                >
+                  로그인
+                </Link>
+              )}
             </div>
           </div>
         </div>

--- a/src/widgets/layout/ui/Navigation.tsx
+++ b/src/widgets/layout/ui/Navigation.tsx
@@ -17,7 +17,7 @@ export default function Navigation() {
     { label: "랭킹", href: "/leaderboards" },
     { label: "패치노트", href: "/patch-notes" },
     // { label: "커뮤니티", href: "/community" },
-    // { label: "듀오 찾기", href: "/duo" },
+    { label: "듀오 찾기", href: "/duo" },
   ];
 
   return (


### PR DESCRIPTION
## 개요

lol-server에 추가된 듀오 API를 실제 서버 컨트롤러/DTO 기준으로 정리해 lol-ui에 연동했습니다. 기존 듀오 UI는 이미 대부분 연결돼 있었고, **실제 서버 계약 대비 빠져 있던 갭만** 메웠습니다.

> 참고: 서버 스펙 문서(`duo-api-spec.md`)는 두 번째 라인을 `secondaryLane`이라 적었으나 **실제 서버 코드는 `desiredLane`** 을 사용합니다(문서가 stale). lol-ui는 이미 `desiredLane`로 맞춰져 있어 리네임은 불필요했습니다. → 서버 문서 수정 권장.

## 변경 사항

- **`match-result` 연동** — `getDuoMatchResult` API + `useDuoMatchResult` 훅 추가. 매칭 성사 시 파트너 게임명·태그라인을 노출:
  - 게시글 소유자: 상세 모달의 MATCHED 게시글에 파트너 배너
  - 요청자: 내 요청 목록의 CONFIRMED 요청 카드에 파트너 표시
- **SSE 실시간 알림** — `useDuoNotifications` 훅 추가(`/duo/notifications/subscribe`). `duo-notification`(REQUEST_ACCEPTED / MATCH_CONFIRMED / REQUEST_CLOSED) 수신마다 듀오 쿼리를 무효화해 목록·상세·내요청이 자동 갱신됩니다. 쿠키 인증, 로그인 시에만 연결, 듀오 페이지 체류 중 구독.
- **`CLOSED` 요청 상태 추가** — 서버가 보내는 `CLOSED`가 UI 타입/라벨/색상에 없어 깨지던 문제 수정(라벨 "종료됨").
- **`Lane` 타입 확장(+`FILL`)** — 서버 `Lane` enum에 맞춰 타입을 넓혀 `LANE_LABELS`/`LANE_IMAGE_KEY` lookup을 total화. 선택 UI에는 기존 5개 라인만 노출하되 예기치 못한 라인 값 렌더 크래시를 방지.

이로써 서버 듀오 엔드포인트 15개(REST 14 + SSE 1)가 모두 UI에 연동됩니다.

## 검증

- `tsc --noEmit`: 0 errors
- `eslint`(변경 파일): 신규 경고 없음 (기존 미사용 import `Pencil` 경고 1건은 본 PR과 무관)
- 백엔드 미가동 환경이라 런타임 E2E는 미수행 — 타입체크+린트로 sanity check.

## 범위 밖 (후속 가능)

- 토스트/알림센터 등 실시간 *UX*는 협의에 따라 제외(데이터 연동까지만).
- `mostChampions`/`recentGameSummary` 화면 렌더링은 보류(타입은 이미 정확).
