### PR TITLE
docs: 로컬에만 있던 패치 데이터(26.7~26.9) 및 세션 노트 보존

### DIFF
--- a/docs/patch/26.7.html
+++ b/docs/patch/26.7.html
@@ -1,0 +1,516 @@
+<!-- url: https://www.leagueoflegends.com/ko-kr/news/game-updates/league-of-legends-patch-26-7-notes/ -->
+<!-- datetime: 2026-03-31T18:00:00.000Z -->
+<div id="patch-notes-container">
+<h2 id="patch-top"></h2>
+
+<div class="context-designers">
+<span class="context-designer" style="text-align:left"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news/1eaf25db2cb788bbb07762d4b879c1598a9ac6ce-200x200.jpg"/> 리루 "Riot Riru" 카브레로스</span>
+</div>
+<div class="context-designers">
+<span class="context-designer" style="text-align:left"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/b36c216eac2e27319ed6c7a5df2dd25e449adee2-220x220.jpg"/> 에리카 "Riot Cashmiir" 하스</span>
+</div>
+<div class="context-designers">
+<span class="context-designer" style="text-align:left"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/ca1ff9c14a7c22252e92199aec42db4e03d24806-300x300.jpg"/> 스티븐 "Riot sternest" 어니스트</span>
+</div>
+<header class="header-primary">
+<h2 id="patch-patch-highlights">패치 하이라이트</h2>
+</header>
+<div class="content-border">
+<div class="white-stone accent-before">
+<div>
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/c97ea280cf7af8edc9b540a66339c1c03dfaa9cb-1920x1080.png" target="_blank"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/c97ea280cf7af8edc9b540a66339c1c03dfaa9cb-1920x1080.png"/></a></span>
+<p>프라이드 치킨 킹 스웨인, 거품 파티 블리츠크랭크, 퍼그 조련사 세주아니, 배불뚝이 켄치, 깜짝 파티 벡스, 프레스티지 구두쇠 모데카이저가 이번 패치 기간에 출시됩니다.</p>
+</div>
+</div>
+</div>
+<header class="header-primary">
+<h2 id="patch-april-fool">2026 만우절</h2>
+</header>
+<div class="content-border">
+<div class="white-stone accent-before">
+<div>
+
+<h3 class="change-title" id="patch-swain">스웨인의 핫 치킨 보상 프로그램</h3>
+
+<div class="table-wrapper"><table style="width:100%; Border: 1px solid white; border-collapse: collapse;">
+<tbody><tr>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; align-items: center;padding:1%;"><strong>업적</strong></td>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;"><strong>보상</strong></td>
+</tr>
+<tr>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;">1</td>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;"><span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/777bddf09c629747b0a404d2c651e3ed7551b9b9-300x300.jpg" target="_blank"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/777bddf09c629747b0a404d2c651e3ed7551b9b9-300x300.jpg" style="margin-left: auto; margin-right: auto;"/></a></span> '부르셨나요?' 아이콘</td>
+</tr>
+<tr>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;">2</td>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;"><span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/924cbe08141d07cac4f1c8bbf46172e5a3d04de8-140x128.png" target="_blank"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/924cbe08141d07cac4f1c8bbf46172e5a3d04de8-140x128.png" style="margin-left: auto; margin-right: auto;"/></a></span> 500 BXP</td>
+</tr>
+<tr>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;">3</td>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;"><span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/e40fa956c7873e776aa4a132fe2c3e98ddd678dc-300x300.jpg" target="_blank"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/e40fa956c7873e776aa4a132fe2c3e98ddd678dc-300x300.jpg" style="margin-left: auto; margin-right: auto;"/></a></span> '보이지 않는 한 입' 아이콘</td>
+</tr>
+<tr>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;">4</td>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;"><span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/7b5bb86e99b2b4ca16491142ab3d208cf84886e0-256x256.png" target="_blank"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/7b5bb86e99b2b4ca16491142ab3d208cf84886e0-256x256.png" style="margin-left: auto; margin-right: auto;"/></a></span> '야아오옹' 감정표현</td>
+</tr>
+<tr>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;">5</td>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;"><span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/37a263ede500d84bf9abf48880d74ada3225b882-256x256.png" target="_blank"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/37a263ede500d84bf9abf48880d74ada3225b882-256x256.png" style="margin-left: auto; margin-right: auto;"/></a></span> '극상의 맛' 감정표현</td>
+</tr>
+<tr>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;">6</td>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;"><span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/23d06dee472588e0ba8ed7aa056cd98705ca762b-256x256.png" target="_blank"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/23d06dee472588e0ba8ed7aa056cd98705ca762b-256x256.png" style="margin-left: auto; margin-right: auto;"/></a></span> '나 아니다' 감정표현</td>
+</tr>
+<tr>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;">7</td>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;"><span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/924cbe08141d07cac4f1c8bbf46172e5a3d04de8-140x128.png" target="_blank"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/924cbe08141d07cac4f1c8bbf46172e5a3d04de8-140x128.png" style="margin-left: auto; margin-right: auto;"/></a></span> 500 BXP</td>
+</tr>
+<tr>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;">8</td>
+<td style="Border: 1px solid white; border-collapse: collapse; text-align:center; padding:1%;"><span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/af0d64365703f9cd608fdc8d5779f3224b5a3192-256x256.png" target="_blank"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/af0d64365703f9cd608fdc8d5779f3224b5a3192-256x256.png" style="margin-left: auto; margin-right: auto;"/></a></span> '바게트 세 개' 감정표현</td>
+</tr>
+</tbody></table></div>
+
+<hr class="divider"/>
+<h4 class="change-detail-title">마법공학 상자 열혈 팬 집합!</h4>
+
+<hr class="divider"/>
+<h4 class="change-detail-title">협곡의 혼돈</h4>
+
+<ul>
+<li>친애하는 카서스 (사망 시 일정 확률로 적에게 카서스 궁극기를 사용합니다.)</li>
+<li>빛나는 미니언 및 몬스터 (일정 확률로 미니언과 몬스터가 빛나며, 처치 시 양 팀 모두 획득할 수 있는 골드를 떨어뜨립니다.)</li>
+<li>골드 획득 아이템 및 골드 획득 아이템으로 조합하는 행운의 우르프 조각상</li>
+<li>빛나는 아이템 (완성 아이템이 일정 확률로 특별, 희귀, 신화 또는 전설 등급이 되며, 약간의 추가 능력치 및 빛나는 테두리를 획득합니다.)</li>
+<li>처치 관여 시 모자 획득</li>
+<li>특정 미니언 및 몬스터가 일정 확률로 변장</li>
+</ul>
+</div>
+</div>
+</div>
+<header class="header-primary">
+<h2 id="patch-champions">챔피언</h2>
+</header>
+<div class="content-border">
+<div class="patch-change-block white-stone accent-before">
+<div>
+<a class="reference-link" href="https://leagueoflegends.com/ko-kr/champions/cassiopeia/"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/champion/Cassiopeia.png"/></a>
+<h3 class="change-title" id="patch-cassiopeia"><a href="https://www.leagueoflegends.com/ko-kr/champions/cassiopeia/">카시오페아</a></h3>
+
+<hr class="divider"/>
+<h4 class="change-detail-title">기본 능력치</h4>
+<ul>
+<li><strong>기본 마나</strong>: 450 ⇒ 480</li>
+</ul>
+<hr class="divider"/>
+<h4 class="change-detail-title ability-title"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/spell/CassiopeiaE.png"/>E - 쌍독니</h4>
+<ul>
+<li><strong>추가 마법 피해량</strong>: 20/43/66/89/112 ⇒ 20/45/70/95/120</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="content-border">
+<div class="patch-change-block white-stone accent-before">
+<div>
+<a class="reference-link" href="https://leagueoflegends.com/ko-kr/champions/graves/"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/champion/Graves.png"/></a>
+<h3 class="change-title" id="patch-graves"><a href="https://www.leagueoflegends.com/ko-kr/champions/graves/">그레이브즈</a></h3>
+
+<hr class="divider"/>
+<h4 class="change-detail-title">기본 능력치</h4>
+<ul>
+<li><strong>기본 공격력</strong>: 68 ⇒ 66</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="content-border">
+<div class="patch-change-block white-stone accent-before">
+<div>
+<a class="reference-link" href="https://leagueoflegends.com/ko-kr/champions/kalista/"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/champion/Kalista.png"/></a>
+<h3 class="change-title" id="patch-kalista"><a href="https://www.leagueoflegends.com/ko-kr/champions/kalista/">칼리스타</a></h3>
+
+<hr class="divider"/>
+<h4 class="change-detail-title ability-title"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/spell/KalistaExpungeWrapper.png"/>E - 뽑아 찢기</h4>
+<ul>
+<li><strong>추가 중첩당 추가 피해량 총공격력 계수</strong>: (+공격력의 20/25/30/35/40%) ⇒ (+공격력의 20/27.5/35/42.5/50%)</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="content-border">
+<div class="patch-change-block white-stone accent-before">
+<div>
+<a class="reference-link" href="https://leagueoflegends.com/ko-kr/champions/karma/"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/champion/Karma.png"/></a>
+<h3 class="change-title" id="patch-karma"><a href="https://www.leagueoflegends.com/ko-kr/champions/karma/">카르마</a></h3>
+
+<hr class="divider"/>
+<h4 class="change-detail-title ability-title"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/spell/KarmaMantra.png"/>R - 만트라</h4>
+<ul>
+<li><strong>강화된 E - 저항 주요/2차 대상 추가 보호막</strong>: 50/100/150/200 (+주문력의 45%) ⇒ 45/85/125/165 (+주문력의 45%)</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="content-border">
+<div class="patch-change-block white-stone accent-before">
+<div>
+<a class="reference-link" href="https://leagueoflegends.com/ko-kr/champions/nami/"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/champion/Nami.png"/></a>
+<h3 class="change-title" id="patch-nami"><a href="https://www.leagueoflegends.com/ko-kr/champions/nami/">나미</a></h3>
+
+<hr class="divider"/>
+<h4 class="change-detail-title ability-title"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/spell/NamiW.png"/>W - 밀물 썰물</h4>
+<ul>
+<li><strong>튕길 시 계수</strong>: 튕길 때마다 효과 -10% (+주문력 100당 10%) ⇒ 튕길 때마다 효과 -20% (+주문력 100당 15%)</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="content-border">
+<div class="patch-change-block white-stone accent-before">
+<div>
+<a class="reference-link" href="https://leagueoflegends.com/ko-kr/champions/ornn/"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/champion/Ornn.png"/></a>
+<h3 class="change-title" id="patch-ornn"><a href="https://www.leagueoflegends.com/ko-kr/champions/ornn/">오른</a></h3>
+
+<hr class="divider"/>
+<h4 class="change-detail-title ability-title"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/spell/OrnnW.png"/>W - 불꽃 풀무질</h4>
+<ul>
+<li><strong>불안정 발동 피해량:</strong> 10~18% (레벨에 따라) ⇒ 9~17% (레벨에 따라)</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="content-border">
+<div class="patch-change-block white-stone accent-before">
+<div>
+<a class="reference-link" href="https://leagueoflegends.com/ko-kr/champions/rell/"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/champion/Rell.png"/></a>
+<h3 class="change-title" id="patch-rell"><a href="https://www.leagueoflegends.com/ko-kr/champions/rell/">렐</a></h3>
+
+<hr class="divider"/>
+<h4 class="change-detail-title ability-title"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/spell/RellE.png"/>E - 전속력</h4>
+<ul>
+<li><strong>이동 속도</strong>: 3초 동안 10%, 강화된 아군 또는 시야에 들어온 적 챔피언과 마주할 때 25%로 증가 ⇒ 15%, 30%로 증가</li>
+</ul>
+<hr class="divider"/>
+<h4 class="change-detail-title ability-title"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/spell/RellR.png"/>R - 자기 폭풍</h4>
+<ul>
+<li><strong>피해량</strong>: 120/200/280 (+주문력의 110%) ⇒ 150/200/350 (+주문력의 110%)</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="content-border">
+<div class="patch-change-block white-stone accent-before">
+<div>
+<a class="reference-link" href="https://leagueoflegends.com/ko-kr/champions/shyvana/"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/champion/Shyvana.png"/></a>
+<h3 class="change-title" id="patch-shyvana"><a href="https://www.leagueoflegends.com/ko-kr/champions/shyvana/">쉬바나</a></h3>
+
+</div>
+</div>
+</div>
+<div class="content-border">
+<div class="patch-change-block white-stone accent-before">
+<div>
+<a class="reference-link" href="https://leagueoflegends.com/ko-kr/champions/singed/"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/champion/Singed.png"/></a>
+<h3 class="change-title" id="patch-singed"><a href="https://www.leagueoflegends.com/ko-kr/champions/singed/">신지드</a></h3>
+
+<hr class="divider"/>
+<h4 class="change-detail-title ability-title"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/spell/InsanityPotion.png"/>R - 광기의 물약</h4>
+<ul>
+<li><strong>추가 능력치</strong>: 25/60/95 ⇒ 25/55/85</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="content-border">
+<div class="patch-change-block white-stone accent-before">
+<div>
+<a class="reference-link" href="https://leagueoflegends.com/ko-kr/champions/veigar/"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/champion/Veigar.png"/></a>
+<h3 class="change-title" id="patch-veigar"><a href="https://www.leagueoflegends.com/ko-kr/champions/veigar/">베이가</a></h3>
+
+<hr class="divider"/>
+<h4 class="change-detail-title ability-title"><img src="https://am-a.akamaihd.net/image?f=https://ddragon.leagueoflegends.com/cdn/16.6.1/img/spell/VeigarR.png"/>R - 태초의 폭발</h4>
+<ul>
+<li><strong>재사용 대기시간</strong>: 100/80/60초 ⇒ 120/90/60초</li>
+</ul>
+</div>
+</div>
+</div>
+<header class="header-primary">
+<h2 id="patch-systems">체계</h2>
+</header>
+<div class="content-border">
+<div class="patch-change-block white-stone accent-before">
+<div>
+<h4 class="change-detail-title">서포터 골드 수급</h4>
+
+</div>
+</div>
+</div>
+<header class="header-primary">
+<h2 id="patch-aram:-mayhem">무작위 총력전: 아수라장</h2>
+</header>
+<div class="content-border">
+<div class="white-stone accent-before">
+<div>
+
+<hr class="divider"/>
+<h4 class="change-detail-title">게임플레이 및 체계 업데이트</h4>
+<ul>
+<li>이번 패치에서는 증강 관련 불편함을 줄이고 챔피언 편의성을 개선하는 데 중점을 두었습니다.</li>
+<li>포로 발사기의 경우, 밀어내기 효과가 근접 챔피언에게 너무 불리하게 작용하지 않도록 조정했습니다. 이제 포로 5마리를 보유해야만 한 번 밀어내며, 전투의 흐름이 끊기지 않도록 재생성 시간을 줄였습니다. 또한, 공허 균열을 약간 조정해 지속 피해가 너무 강력하지 않도록 했습니다.</li>
+</ul>
+<hr class="divider"/>
+<h4 class="change-detail-title">버그 수정 및 개선 사항</h4>
+<ul>
+<li>이번 패치에서는 여러 챔피언 관련 상호작용, 특히 상점 및 증강 관련 오류를 수정했습니다. 또한 퀸카 매혹 상호작용, 쉬바나와 최후의 도시 대중교통, 니코와 불여우 문제, 아지르의 소환술사 작동 방식 수정 등 계속해서 증강 전반의 사용 편의성을 개선했습니다.</li>
+</ul>
+
+<hr class="divider"/>
+<h4 class="change-detail-title">증강</h4><strong>포로 발사기</strong>
+<ul>
+<li><span style="background-color:#53ad56"><strong> 신규 </strong></span> 포로를 5마리 보유하고 있을 때만 적을 한 번 밀어냅니다.</li>
+<li>포로 재생성 시간: 5초 ⇒ 3.5초</li>
+</ul><br/> <strong>공허 균열</strong>
+<ul>
+<li>대상별 재사용 대기시간 0.75초가 추가되었습니다.</li>
+</ul>
+<hr class="divider"/>
+<h4 class="change-detail-title">챔피언</h4><strong>쉬바나</strong>
+<ul>
+<li>분노 생성량: 1.25 ⇒ 2.5</li>
+</ul>
+<hr class="divider"/>
+<h4 class="change-detail-title">만우절</h4><strong>복수심에 불타는 포로</strong>
+<ul>
+<li>이제 포로가 근육질 팔을 이용해 움직이며 포로 간식을 쌓아둔 플레이어를 공격합니다. 포로 중 하나가 포로 간식을 먹을 때까지 반복해서 1의 고정 피해를 입힙니다.</li>
+</ul><br/> <strong>명랑한 포로</strong>
+<ul>
+<li>게임 시작 시 포로(또는 부두 쥐)가 채팅으로 플레이어 여러분을 맞이합니다.</li>
+</ul><br/> <strong>포로 간식</strong>
+<ul>
+<li>이제 포로 간식 외형이 치즈버거로 바뀝니다.</li>
+</ul><br/> <strong>점멸</strong>
+<ul>
+<li>점멸 사용 시 감정표현을 하는 잔상이 남습니다.</li>
+</ul><br/> <strong>체력 바 크기 증가</strong>
+<ul>
+<li>체력 바가 챔피언 크기에 비례하여 커집니다.</li>
+</ul><br/> <strong>포탑</strong>
+<ul>
+<li>포탑이 챔피언을 처치하면 숙련도를 표시하고, 파괴되면 감정표현을 사용합니다. 포탑에 의해 사망할 경우 일정 확률로 자신에게 사라짐 신호를 보냅니다.</li>
+</ul><br/> <strong>친애하는 카서스</strong>
+<ul>
+<li>카서스가 6레벨에 도달하면 낮은 확률로 카서스를 대상으로 하는 자동 채팅 메시지가 표시됩니다.</li>
+</ul><br/> <strong>칼바람 나락</strong>
+<ul>
+<li>게임 종료 시 낮은 확률로 리산드라가 메시지를 보냅니다.</li>
+</ul><br/> <strong>파티 선물</strong>
+<ul>
+<li>상점에 신규 아이템인 파티 선물이 입고되었습니다. 사용 시 댄스 파티를 시작하거나 참여합니다. 참가자는 많을수록 좋습니다!</li>
+</ul><br/> <strong>맞춤형 체력 바 색상</strong>
+<ul>
+<li>상점에 신규 아이템인 맞춤형 체력 바가 입고되었습니다. 아이템 구매 시 구매자의 체력 바가 자동으로 해당 색상으로 변경됩니다.</li>
+</ul>
+<hr class="divider"/>
+<h4 class="change-detail-title">자동 선택 및 부역할군 대전 검색 개선</h4>
+
+<hr class="divider"/>
+<h4 class="change-detail-title">편의성 개선 사항</h4>
+<ul>
+<li>능력치와 직접적으로 상호작용하는 모든 챔피언 스킬(야스오 Q - 강철 폭풍 재사용 대기시간, 카이사의 진화 등)이 이제 무작위 총력전: 아수라장에서 능력치 모루의 영향을 받습니다.</li>
+<li>워모그의 갑옷을 보유했다면 더 이상 흡혈병이 제시되지 않습니다.</li>
+<li>루난의 허리케인을 보유했다면 더 이상 검을 뽑아라가 제시되지 않습니다.</li>
+<li>이제 케인이 형태를 선택한 이후에도 상점을 이용할 수 있습니다.</li>
+<li>이제 유미가 아군에게 밀착한 이후에도 상점을 이용할 수 있습니다.</li>
+<li>이제 드롭킥이 대상 챔피언의 처형 표식을 덮어쓰지 않습니다.</li>
+<li>이제 꼬마 전설이가 미니맵에 아이콘으로 표시되지 않습니다.</li>
+</ul>
+<hr class="divider"/>
+<h4 class="change-detail-title">버그 수정</h4>
+<ul>
+<li>쉬바나가 최후의 도시 대중교통으로 사망 시 분노를 잃던 버그를 수정했습니다.</li>
+<li>아지르의 W - 일어나라! 병사 피해량이 소환술사에 의해 증가하지 않던 버그를 수정했습니다.</li>
+<li>카타리나의 Q - 단검 투척과 W - 준비가 도망갈 수 없어를 발동시키던 버그를 수정했습니다.</li>
+<li>멜이 W - 반박으로 컵케이크 조심해!를 반사하고 생성된 컵케이크에서 골드를 획득할 수 있던 버그를 수정했습니다.</li>
+<li>니코가 불여우를 선택하면 형태 변신이 중단되던 버그를 수정했습니다.</li>
+<li>특정 증강을 선택한 후 갱플랭크의 E - 화약통 재사용 대기시간이 적용되지 않던 버그를 수정했습니다.</li>
+<li>마법공학 흡혈병을 보유한 샤코가 사망 전에 R - 환각을 사용한 경우 체력이 0인 분신이 사라지지 않던 버그를 수정했습니다.</li>
+<li>나는 왕이다를 보유한 비에고가 지배 상태에서 벗어난 후 모든 아이템이 업그레이드되던 버그를 수정했습니다.</li>
+<li>이제 코그모의 W - 생체마법 폭격이 양손잡이 증강 투사체에도 정상적으로 적용됩니다.</li>
+<li>멜 Q - 빛의 세례가 부정 행위와 판도라의 상자를 획득한 후 너무 오래 지속되던 버그를 수정했습니다.</li>
+<li>궁극의 각성이 렝가의 기본 스킬 재사용 대기시간을 초기화하지 않던 버그를 수정했습니다.</li>
+<li>궁극기 대변혁을 보유한 사이온이 좀비 상태에서 R - 죽음의 물결을 사용하면 지속시간이 비정상적으로 초기화되던 버그를 수정했습니다.</li>
+<li>빵과 잼을 선택할 경우 피들스틱의 W - 풍작을 끝까지 사용해도 재사용 대기시간이 정상적으로 반환되지 않던 버그를 수정했습니다.</li>
+<li>사미라의 Q - 천부적 재능 재사용 대기시간이 E - 거침없는 질주 Q - 천부적 재능 연계 후 정상적으로 반환되지 않던 버그를 수정했습니다.</li>
+<li>벼락 공격 속도가 야스오의 Q - 강철 폭풍 재사용 대기시간을 감소시키지 않던 버그를 수정했습니다.</li>
+<li>선동을 보유한 탈리야가 R - 바위술사의 벽을 연타하여 체력을 회복할 수 있던 버그를 수정했습니다.</li>
+<li>광대 대학의 속임수 주문과 렐의 스킬을 함께 사용할 경우 렐의 모델이 지하에 끼던 버그를 수정했습니다.</li>
+<li>돌진 선택 후 그레이브즈의 R - 무고한 희생자 재사용 대기시간이 감소하지 않던 버그를 수정했습니다.</li>
+<li>킨드레드가 궁극의 각성으로 R - 양의 안식처를 사용한 후 킨드레드의 스킬이 초기화되지 않던 버그를 수정했습니다.</li>
+<li>하이머딩거가 R - 업그레이드!!!를 활성화하는 것만으로 처형 시간이 발동되던 버그를 수정했습니다.</li>
+<li>처형 시간을 보유한 탐 켄치가 R - 집어삼키기 사용에 실패하더라도 룬 효과가 발동되던 버그를 수정했습니다.</li>
+<li>레넥톤이 광대 대학의 속임수 효과 중 W - 무자비한 포식자를 사용한 후에도 은신이 유지되던 버그를 수정했습니다.</li>
+<li>우디르가 광대 대학의 속임수 효과 중 R - 날개 돋친 폭풍을 사용한 후에도 투명이 유지되던 버그를 수정했습니다.</li>
+<li>여러 스킬이 동시에 적에게 적중한 경우 노련한 저격수가 재사용 대기시간을 반환하지 않던 버그를 수정했습니다.</li>
+<li>비에고가 강철심장을 보유한 챔피언으로 변신했다가 원래 모습으로 돌아온 후에도 적에게 강철심장 아이콘이 계속 표시되던 버그를 수정했습니다.</li>
+<li>자신에게 군중 제어 효과 적용했을 때 거석상의 용기가 발동되던 버그를 수정했습니다.</li>
+<li>마법공학의 영혼 선택 전에 다수의 모루를 구매할 경우 마법공학의 영혼이 사라지던 버그를 수정했습니다.</li>
+<li>검을 뽑아라를 선택한 후 루난의 허리케인을 구매할 수 있던 버그를 수정했습니다.</li>
+<li>꼬마 전설이의 주인이 사망할 경우 적 기지에서 해당 꼬마 전설이가 보이던 버그를 수정했습니다.</li>
+<li>양자 연산의 재사용 대기시간이 사망한 상태에서 활성화되던 버그를 수정했습니다.</li>
+<li>판도라의 상자로 검을 뽑아라 증강이 다른 증강으로 변경된 이후에도 근접 챔피언으로 간주되던 버그를 수정했습니다.</li>
+<li>넘을 수 없는 벽의 빙결 강화가 재사용 대기시간이 적용되기 전에 여러 번 발동되던 버그를 수정했습니다.</li>
+<li>궁극의 각성 실제 재사용 대기시간이 툴팁에 명시된 20초가 아닌 35초로 적용되던 버그를 수정했습니다.</li>
+<li>치명적 가속이 피해량 증강으로 분류되던 버그를 수정했습니다.</li>
+<li>신념을 통한 강화가 WASD를 사용할 경우 이동을 방해하던 버그를 수정했습니다.</li>
+<li>아트마의 심판이 부여된 스킬 가속을 표시하지 않던 버그를 수정했습니다.</li>
+<li>끊임없는 회복을 처음 선택했을 때 체력이 과도하게 회복되던 버그를 수정했습니다.</li>
+<li>포로 발사기가 대상으로 지정할 수 없는 챔피언을 밀어내던 버그를 수정했습니다.</li>
+<li>눈덩이 업그레이드 툴팁에 적중당한 적 주변 지역이 드러난다고 잘못 표시되어 있던 버그를 수정했습니다.</li>
+<li>데굴데굴 눈덩이!를 보유한 상태에서 표식으로 적을 맞힐 경우 눈덩이 업그레이드 둔화가 적용되지 않던 버그를 수정했습니다.</li>
+<li>돌진이 있는 눈덩이를 보유한 상태에서 눈덩이 증강을 선택할 경우 눈덩이 소환사 주문이 2개 제공되던 버그를 수정했습니다.</li>
+<li>업그레이드된 리치베인 기본 지속 효과 툴팁의 간격이 잘못 표시되던 버그를 수정했습니다.</li>
+<li>퀸카를 보유한 상태로 사망 시 주변 챔피언 및 미니언을 매혹하던 버그를 수정했습니다.</li>
+<li>점멸 2 사용 후 일부 점멸 음향 효과가 누락되던 버그를 수정했습니다.</li>
+<li>이제 지옥불 난사 발동이 정상적으로 고유 사용 횟수를 확인합니다.</li>
+<li>사망한 상태에서 자폭을 선택하면 해당 증강이 즉시 발동되던 버그를 수정했습니다.</li>
+<li>밴시의 장막이 컵케이크 조심해!와 상호작용 시 재사용 대기시간은 적용되지만 체력은 회복되지 않던 버그를 수정했습니다.</li>
+<li>컵케이크 조심해!가 바람 장막에 의해 파괴되던 버그를 수정했습니다.</li>
+<li>탭 댄서가 채팅에 표시될 때 증강 이름이 누락되던 버그를 수정했습니다.</li>
+<li>사망한 상태에서 남작의 도움을 획득할 경우 시각 효과가 반복되던 버그를 수정했습니다.</li>
+<li>사망한 상태에서 남작의 도움을 시각 효과가 사라지지 않던 버그를 수정했습니다.</li>
+</ul>
+</div>
+</div>
+</div>
+<header class="header-primary">
+<h2 id="patch-demacia-rising">떠오르는 데마시아</h2>
+</header>
+<div class="content-border">
+<div class="white-stone accent-before">
+<div>
+
+<hr class="divider"/>
+<ul>
+<li><strong>이야기 및 보상</strong>: 제7장과 제8장이 16개의 신규 목표와 함께 찾아옵니다. 제7장을 완료하고 럭스의 갬빗 아이콘을, 제8장을 완료하고 2026 졸업반 감정표현을 획득하세요. 모든 연구를 잠금 해제하고 떠오르는 데마시아 휘장을 획득하세요.</li>
+<li><strong>신규 정착지</strong>: 총 4곳의 신규 정착지가 추가되었습니다. 회색 관문(중심지), 브렌 토르(산간), 렌월(산간), 림베일(국경)입니다.</li>
+<li><strong>챔피언</strong>: 자르반 4세와 퀸을 사용할 수 있습니다.</li>
+<li>자르반 4세는 근접 유닛에게 추가 공격력을 부여하는 전방 사령관입니다.</li>
+<li>퀸은 적의 후방을 노립니다. 퀸은 발러를 보내 적 원거리 공격 유닛을 타격합니다.</li>
+<li><strong>구조물</strong>: 모든 마을과 자원 생산지(페트리사이트 제련소 제외)를 5레벨로 업그레이드할 수 있습니다. 또한, 연구에서 몇 가지 신규 고유 구조물을 해금할 수 있으며, 이는 다음과 같습니다.</li>
+<li>칼날부리 사육장: 사육장은 칼날부리 기사를 보내 주변 정착지를 방어합니다. 이 구조물을 업그레이드하면 칼날부리 기사의 공격 빈도가 증가합니다. 칼날부리 사육장은 새로운 정착지를 확보하고 위험한 위협에 맞서 방어하는 데 매우 유용합니다.</li>
+<li>잿빛요새: 잿빛요새를 건설하면 5개의 고유 연계 이벤트가 시작되며, 각 이벤트는 왕국 또는 유닛을 영구적으로 변화시킵니다.</li>
+<li><strong>연구</strong>: 케일과 모르가나 업그레이드를 포함한 16개의 신규 연구 항목을 이용할 수 있습니다.</li>
+</ul>
+</div>
+</div>
+</div>
+<header class="header-primary">
+<h2 id="patch-ranked">랭크 게임</h2>
+</header>
+<div class="content-border">
+<div class="white-stone accent-before">
+<div>
+
+</div>
+</div>
+</div>
+<header class="header-primary">
+<h2 id="patch-bugfixes-and-quality-of-life-changes">버그 수정 및 편의성 개선 사항</h2>
+</header>
+<div class="content-border">
+<div class="white-stone accent-before">
+<div>
+<ul>
+<li>특정 스킨 사용 시 쉬바나의 인간 및 용 형상에서 Q - 잉걸불 일격 음향 효과가 출력되지 않던 버그를 수정했습니다.</li>
+<li>멜이 W - 반박을 사용해 자크의 Q - 탄성 주먹을 막은 후 Q - 빛의 세례 재사용 대기시간이 적용되던 버그를 수정했습니다.</li>
+<li>아이번 E - 보호의 씨앗 보호막 피해량이 사미라의 기본 지속 효과 - 무모한 충동에 집계되던 버그를 수정했습니다.</li>
+<li>리븐이 갈라진 하늘 또는 악마사냥꾼의 화살 등의 아이템으로 치명타 적중 시 기본 지속 효과 - 룬 검 피해량이 감소하지 않던 버그를 수정했습니다.</li>
+<li>챔피언에게 게임이 끝날 때까지 시야 표시가 남아 있던 버그를 수정했습니다.</li>
+<li>실명 상태일 때 루난의 허리케인 추가 탄환이 피해를 입히고 적중 시 효과를 적용하던 버그를 수정했습니다.</li>
+<li>연습 모드에서 게임 초기화 기능 사용 시 포탑의 피해량 감소 효과가 의도한 것보다 더 높게 적용되던 버그를 수정했습니다.</li>
+<li>트위스티드 페이트의 W - 카드 뽑기가 치명타가 발동되지 않음에도 악마사냥꾼의 화살 중첩을 소모하던 버그를 수정했습니다.</li>
+<li>신속 대전 점수판에 해당 게임 모드에 등장하지 않는 공허 유충 및 협곡의 전령 개수가 표시되던 버그를 수정했습니다.</li>
+</ul>
+</div>
+</div>
+</div>
+<header class="header-primary">
+<h2 id="patch-upcoming-skins-and-chromas">앞으로 나올 스킨 및 크로마</h2>
+</header>
+<div class="content-border">
+<div class="white-stone accent-before">
+<div>
+<p>이번 패치 기간 내에 다음과 같은 스킨이 출시됩니다.</p>
+<div class="gs-container default-2-col">
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/13375a6633f09dee4e4397083ca37fc294592203-1920x1133.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/13375a6633f09dee4e4397083ca37fc294592203-1920x1133.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/13375a6633f09dee4e4397083ca37fc294592203-1920x1133.jpg" target="_blank">프라이드 치킨 킹 스웨인</a></h4>
+</div>
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/e6f080f4445543b436e052acda4befbf510cc1bf-1920x1133.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/e6f080f4445543b436e052acda4befbf510cc1bf-1920x1133.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/e6f080f4445543b436e052acda4befbf510cc1bf-1920x1133.jpg" target="_blank">거품 파티 블리츠크랭크</a></h4>
+</div>
+</div>
+<div class="gs-container default-2-col">
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/06bb315cc0bed6bbee63b87765cfe98f14dc1d5f-1920x1133.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/06bb315cc0bed6bbee63b87765cfe98f14dc1d5f-1920x1133.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/06bb315cc0bed6bbee63b87765cfe98f14dc1d5f-1920x1133.jpg" target="_blank">프레스티지 구두쇠 모데카이저</a></h4>
+</div>
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/99802e96dd69a7d869a0f63a212dddff54a55c12-1920x1133.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/99802e96dd69a7d869a0f63a212dddff54a55c12-1920x1133.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/99802e96dd69a7d869a0f63a212dddff54a55c12-1920x1133.jpg" target="_blank">퍼그 조련사 세주아니</a></h4>
+</div>
+</div>
+<div class="gs-container default-2-col">
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/828327a983d5e7e2b48c98044f78bc9a6fa90fac-1920x1132.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/828327a983d5e7e2b48c98044f78bc9a6fa90fac-1920x1132.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/828327a983d5e7e2b48c98044f78bc9a6fa90fac-1920x1132.jpg" target="_blank">배불뚝이 켄치</a></h4>
+</div>
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/b73d4406663c050c5e4043710ab6a1d29996f65a-1920x1127.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/b73d4406663c050c5e4043710ab6a1d29996f65a-1920x1127.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/b73d4406663c050c5e4043710ab6a1d29996f65a-1920x1127.jpg" target="_blank">깜짝 파티 벡스</a></h4>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="content-border">
+<div class="white-stone accent-before">
+<div>
+<p>이번 패치 기간 내에 다음과 같은 크로마가 출시됩니다.</p>
+<div class="gs-container default-2-col">
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/ff69af0ae38dd18333aaaaec6511ef068ce6018c-1610x590.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/ff69af0ae38dd18333aaaaec6511ef068ce6018c-1610x590.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/ff69af0ae38dd18333aaaaec6511ef068ce6018c-1610x590.jpg" target="_blank">프라이드 치킨 킹 스웨인</a></h4>
+</div>
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/96d2df975913d3a5655a5210207ba6c5f3e4f4ae-1610x562.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/96d2df975913d3a5655a5210207ba6c5f3e4f4ae-1610x562.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/96d2df975913d3a5655a5210207ba6c5f3e4f4ae-1610x562.jpg" target="_blank">거품 파티 블리츠크랭크</a></h4>
+</div>
+</div>
+<div class="gs-container default-2-col">
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/6727f2e249ac64a1cbcf96449e5e06a888d9ce3a-1610x590.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/6727f2e249ac64a1cbcf96449e5e06a888d9ce3a-1610x590.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/6727f2e249ac64a1cbcf96449e5e06a888d9ce3a-1610x590.jpg" target="_blank">프레스티지 구두쇠 모데카이저</a></h4>
+</div>
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/963a8a163c8053a913cfc78929ea0746e2ac211e-1610x587.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/963a8a163c8053a913cfc78929ea0746e2ac211e-1610x587.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/963a8a163c8053a913cfc78929ea0746e2ac211e-1610x587.jpg" target="_blank">퍼그 조련사 세주아니</a></h4>
+</div>
+</div>
+<div class="gs-container default-2-col">
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/492bdab6dbdc7aac952276c2e54b707fe2c9f5ee-1610x467.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/492bdab6dbdc7aac952276c2e54b707fe2c9f5ee-1610x467.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/492bdab6dbdc7aac952276c2e54b707fe2c9f5ee-1610x467.jpg" target="_blank">배불뚝이 켄치</a></h4>
+</div>
+<div class="skin-box">
+<span class="content-border"><a class="skins cboxElement" href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/5143ab9e9fa7c2faeaadc5d9012d51b769762fce-1610x590.jpg"><img src="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/5143ab9e9fa7c2faeaadc5d9012d51b769762fce-1610x590.jpg"/></a></span>
+<h4 class="skin-title"><a href="https://cmsassets.rgpub.io/sanity/images/dsfx7636/news_live/5143ab9e9fa7c2faeaadc5d9012d51b769762fce-1610x590.jpg" target="_blank">깜짝 파티 벡스</a></h4>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>

--- a/docs/patch/26.7.json
+++ b/docs/patch/26.7.json
@@ -1,0 +1,146 @@
+{
+  "version": "26.7",
+  "url": "https://www.leagueoflegends.com/ko-kr/news/game-updates/league-of-legends-patch-26-7-notes/",
+  "date": "2026-03-31",
+  "rift": {
+    "champions": [
+      {
+        "targetName": "카시오페아",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          {
+            "statName": "기본 마나",
+            "before": "450",
+            "after": "480"
+          },
+          {
+            "statName": "E - 쌍독니 추가 마법 피해량",
+            "before": "20/43/66/89/112",
+            "after": "20/45/70/95/120"
+          }
+        ]
+      },
+      {
+        "targetName": "그레이브즈",
+        "type": "champion",
+        "direction": "nerf",
+        "changes": [
+          {
+            "statName": "기본 공격력",
+            "before": "68",
+            "after": "66"
+          }
+        ]
+      },
+      {
+        "targetName": "칼리스타",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          {
+            "statName": "E - 뽑아 찢기 추가 중첩당 추가 피해량 총공격력 계수",
+            "before": "(+공격력의 20/25/30/35/40%)",
+            "after": "(+공격력의 20/27.5/35/42.5/50%)"
+          }
+        ]
+      },
+      {
+        "targetName": "카르마",
+        "type": "champion",
+        "direction": "nerf",
+        "changes": [
+          {
+            "statName": "R - 만트라 강화된 E - 저항 주요/2차 대상 추가 보호막",
+            "before": "50/100/150/200 (+주문력의 45%)",
+            "after": "45/85/125/165 (+주문력의 45%)"
+          }
+        ]
+      },
+      {
+        "targetName": "나미",
+        "type": "champion",
+        "direction": "nerf",
+        "changes": [
+          {
+            "statName": "W - 밀물 썰물 튕길 시 계수",
+            "before": "튕길 때마다 효과 -10% (+주문력 100당 10%)",
+            "after": "튕길 때마다 효과 -20% (+주문력 100당 15%)"
+          }
+        ]
+      },
+      {
+        "targetName": "오른",
+        "type": "champion",
+        "direction": "nerf",
+        "changes": [
+          {
+            "statName": "W - 불꽃 풀무질 불안정 발동 피해량",
+            "before": "10~18% (레벨에 따라)",
+            "after": "9~17% (레벨에 따라)"
+          }
+        ]
+      },
+      {
+        "targetName": "렐",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          {
+            "statName": "E - 전속력 이동 속도",
+            "before": "3초 동안 10%, 강화된 아군 또는 시야에 들어온 적 챔피언과 마주할 때 25%로 증가",
+            "after": "15%, 30%로 증가"
+          },
+          {
+            "statName": "R - 자기 폭풍 피해량",
+            "before": "120/200/280 (+주문력의 110%)",
+            "after": "150/200/350 (+주문력의 110%)"
+          }
+        ]
+      },
+      {
+        "targetName": "쉬바나",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": [
+          {
+            "statName": "R - 용의 강림",
+            "before": "",
+            "after": "이제 궁극기 가속이 초당 0.015 기본 지속 효과 분노를 생성하지 않으며, 대신 궁극기 가속 1당 모든 분노 생성량이 1% 증가합니다."
+          }
+        ]
+      },
+      {
+        "targetName": "신지드",
+        "type": "champion",
+        "direction": "nerf",
+        "changes": [
+          {
+            "statName": "R - 광기의 물약 추가 능력치",
+            "before": "25/60/95",
+            "after": "25/55/85"
+          }
+        ]
+      },
+      {
+        "targetName": "베이가",
+        "type": "champion",
+        "direction": "nerf",
+        "changes": [
+          {
+            "statName": "R - 태초의 폭발 재사용 대기시간",
+            "before": "100/80/60초",
+            "after": "120/90/60초"
+          }
+        ]
+      }
+    ],
+    "items": [],
+    "systems": []
+  },
+  "arena": {
+    "champions": [],
+    "items": [],
+    "systems": []
+  }
+}

--- a/docs/patch/26.8.json
+++ b/docs/patch/26.8.json
@@ -1,0 +1,269 @@
+{
+  "version": "26.8",
+  "url": "https://www.leagueoflegends.com/ko-kr/news/game-updates/league-of-legends-patch-26-8-notes/",
+  "date": "2026-04-14",
+  "rift": {
+    "champions": [
+      {
+        "targetName": "문도 박사",
+        "type": "champion",
+        "direction": "nerf",
+        "changes": [
+          { "statName": "Q - 오염된 뼈톱 몬스터 대상 최대 피해량", "before": "300/375/450/525/600", "after": "250/325/400/475/550" },
+          { "statName": "E - 둔기에 의한 외상 몬스터 대상 최대 피해량", "before": "200%", "after": "140%" }
+        ]
+      },
+      {
+        "targetName": "흐웨이",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "기본 지속 효과 기본 피해량", "before": "35~230 (레벨에 따라)", "after": "40~285 (레벨에 따라)" },
+          { "statName": "둔화 효과 연계", "before": "흐웨이의 스킬이 유발한 둔화 효과가 서로 중첩되지 않음", "after": "이제 흐웨이의 스킬이 유발한 둔화 효과가 서로 중첩되지만, 대신 그 횟수에 따라 둔화율이 점차 감소합니다." }
+        ]
+      },
+      {
+        "targetName": "카르마",
+        "type": "champion",
+        "direction": "nerf",
+        "changes": [
+          { "statName": "기본 공격력", "before": "51", "after": "49" },
+          { "statName": "공격력 증가량", "before": "3.3", "after": "3.0" },
+          { "statName": "E - 고무 마나 소모량", "before": "50/55/60/65/70", "after": "60/65/70/75/80" }
+        ]
+      },
+      {
+        "targetName": "릴리아",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "기본 지속 효과 - 꿈나무 지팡이 몬스터 대상 최대 피해량", "before": "65", "after": "70~180 (레벨에 따라)" }
+        ]
+      },
+      {
+        "targetName": "루시안",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "E - 끈질긴 추격 재사용 대기시간", "before": "18/17/16/15/14초", "after": "16/15.5/15/14.5/14초" },
+          { "statName": "E - 끈질긴 추격 마나 소모량", "before": "40/30/20/10/0", "after": "32/24/16/8/0" }
+        ]
+      },
+      {
+        "targetName": "멜",
+        "type": "champion",
+        "direction": "nerf",
+        "changes": [
+          { "statName": "Q - 빛의 세례 첫 번째 폭발 피해량", "before": "60/90/120/150/180 (+주문력의 60%)", "after": "60/85/110/135/160 (+주문력의 55%)" },
+          { "statName": "W - 반박 재사용 대기시간", "before": "35/32/29/26/23초", "after": "38/35/32/29/26초" },
+          { "statName": "W - 반박 추가 이동 속도 지속시간", "before": "1.5초", "after": "0.75초" }
+        ]
+      },
+      {
+        "targetName": "탐 켄치",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": [
+          { "statName": "기본 지속 효과 - 절대 미각 피해량", "before": "6~48 (1~11레벨) (+추가 체력 100당 주문력의 1.5%) (+추가 체력의 4.5%)", "after": "5~60 (1~12레벨) (+추가 체력 100당 주문력의 1.25%) (+추가 체력의 4%)" }
+        ]
+      },
+      {
+        "targetName": "유미",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": [
+          { "statName": "R - 대단원 파동 1회당 체력 회복량", "before": "30/40/50 (+주문력의 10%)", "after": "30/50/70 (+주문력의 12%)" },
+          { "statName": "R - 대단원 단짝 강화된 체력 회복량", "before": "체력 회복량 30% 증가", "after": "체력 회복량 30~60% 증가 (6~12레벨)" }
+        ]
+      },
+      {
+        "targetName": "질리언",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": [
+          { "statName": "W - 되감기 레벨 업", "before": "1레벨에 W - 되감기를 배울 수 있음", "after": "이제 1레벨에 W - 되감기를 배울 수 없습니다." }
+        ]
+      },
+      {
+        "targetName": "자이라",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": [
+          { "statName": "W - 맹렬한 성장 레벨 업", "before": "1레벨에 W - 맹렬한 성장을 배울 수 있음", "after": "이제 1레벨에 W - 맹렬한 성장을 배울 수 없습니다." }
+        ]
+      }
+    ],
+    "items": [],
+    "systems": []
+  },
+  "arena": {
+    "champions": [
+      {
+        "targetName": "트리스타나",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "W - 로켓 점프 주문력 계수", "before": "주문력의 50%", "after": "주문력의 80%" },
+          { "statName": "E - 폭발 화약 주문력 계수", "before": "주문력의 50%", "after": "주문력의 80%" },
+          { "statName": "R - 대구경 탄환 주문력 계수", "before": "주문력의 100%", "after": "주문력의 150%" }
+        ]
+      },
+      {
+        "targetName": "시비르",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "Q - 부메랑 검 주문력 계수", "before": "주문력의 60%", "after": "주문력의 80%" },
+          { "statName": "E - 주문 방어막 주문력 계수", "before": "주문력의 50%", "after": "주문력의 120%" }
+        ]
+      },
+      {
+        "targetName": "자르반 4세",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "E - 데마시아의 깃발 주문력 계수", "before": "주문력의 100%", "after": "주문력의 140%" }
+        ]
+      },
+      {
+        "targetName": "세나",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "Q - 꿰뚫는 어둠 피해량 주문력 계수", "before": "주문력의 50%", "after": "주문력의 80%" },
+          { "statName": "Q - 꿰뚫는 어둠 둔화율 주문력 계수", "before": "주문력의 10%", "after": "주문력의 15%" },
+          { "statName": "E - 검은 안개의 저주 이동 속도 주문력 계수", "before": "주문력의 5%", "after": "주문력의 7%" },
+          { "statName": "R - 여명의 그림자 피해량 주문력 계수", "before": "주문력의 70%", "after": "주문력의 100%" },
+          { "statName": "R - 여명의 그림자 보호막 흡수량 주문력 계수", "before": "주문력의 50%", "after": "주문력의 70%" }
+        ]
+      },
+      {
+        "targetName": "사이온",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "W - 영혼의 용광로 보호막 흡수량 주문력 계수", "before": "주문력의 40%", "after": "주문력의 60%" },
+          { "statName": "W - 영혼의 용광로 피해량 주문력 계수", "before": "주문력의 40%", "after": "주문력의 60%" }
+        ]
+      },
+      {
+        "targetName": "벡스",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "R - 그림자 파동 재사용 대기시간", "before": "140/120/100초", "after": "110/90/70초" }
+        ]
+      },
+      {
+        "targetName": "세라핀",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "Q - 고음 피해량 주문력 계수", "before": "주문력의 50%", "after": "주문력의 65%" },
+          { "statName": "R - 앙코르 재사용 대기시간", "before": "160/140/120초", "after": "100/80/60초" }
+        ]
+      },
+      {
+        "targetName": "벨코즈",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "R - 생물 분해 광선 재사용 대기시간", "before": "100/90/80초", "after": "80/70/60초" }
+        ]
+      },
+      {
+        "targetName": "빅토르",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "R - 아케인 폭풍 재사용 대기시간", "before": "120/100/80초", "after": "100/80/60초" }
+        ]
+      },
+      {
+        "targetName": "카밀",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "W - 전술적 휩쓸기 피해량", "before": "추가 공격력 100당 2.5%", "after": "추가 공격력 100당 3%" },
+          { "statName": "E - 갈고리 발사 재사용 대기시간", "before": "16/15/14/13/12초", "after": "14/13/12/11/10초" }
+        ]
+      },
+      {
+        "targetName": "클레드",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          { "statName": "R - 돌겨어어억!!! 재사용 대기시간", "before": "140/125/110초", "after": "60/45/30초" }
+        ]
+      }
+    ],
+    "items": [],
+    "systems": [
+      {
+        "targetName": "탄환 세례",
+        "type": "augment",
+        "direction": "nerf",
+        "changes": [
+          { "statName": "탄환 1개당 피해량", "before": "10~52.5 (+추가 공격력의 15%)", "after": "8~51 (+추가 공격력의 14%)" }
+        ]
+      },
+      {
+        "targetName": "거인 학살자",
+        "type": "augment",
+        "direction": "nerf",
+        "changes": [
+          { "statName": "이동 속도", "before": "30%", "after": "20%" }
+        ]
+      },
+      {
+        "targetName": "할머니의 고추기름",
+        "type": "augment",
+        "direction": "nerf",
+        "changes": [
+          { "statName": "아군 미니언 체력 회복", "before": "아군 미니언의 체력을 회복시킴", "after": "이제 아군 미니언의 체력을 회복시키지 않습니다." }
+        ]
+      },
+      {
+        "targetName": "이동 속도 능력치 모루",
+        "type": "anvil",
+        "direction": "nerf",
+        "changes": [
+          { "statName": "이동 속도", "before": "18%", "after": "15%" }
+        ]
+      },
+      {
+        "targetName": "민병대",
+        "type": "augment",
+        "direction": "nerf",
+        "changes": [
+          { "statName": "피해를 받은 뒤 추가 이동 속도 재발동 대기시간", "before": "3초", "after": "6초" }
+        ]
+      },
+      {
+        "targetName": "양자 연산",
+        "type": "augment",
+        "direction": "buff",
+        "changes": [
+          { "statName": "범위 바깥쪽 피해량", "before": "200~350 (+추가 공격력의 65%) (+주문력의 40%)", "after": "200~350 (+추가 공격력의 75%) (+주문력의 45%)" }
+        ]
+      },
+      {
+        "targetName": "붉은 봉투",
+        "type": "augment",
+        "direction": "nerf",
+        "changes": [
+          { "statName": "붉은 봉투 획득 시 이동 속도", "before": "150", "after": "100" },
+          { "statName": "이동 속도 지속시간", "before": "4초", "after": "3초" }
+        ]
+      },
+      {
+        "targetName": "속행",
+        "type": "augment",
+        "direction": "nerf",
+        "changes": [
+          { "statName": "스킬 가속으로 얻는 이동 속도", "before": "100%", "after": "70%" }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/patch/26.9.json
+++ b/docs/patch/26.9.json
@@ -1,0 +1,330 @@
+{
+  "version": "26.9",
+  "url": "https://www.leagueoflegends.com/ko-kr/news/game-updates/league-of-legends-patch-26-9-notes/",
+  "date": "2026-04-28",
+  "rift": {
+    "champions": [
+      {
+        "targetName": "암베사",
+        "type": "champion",
+        "direction": "nerf",
+        "changes": [
+          {
+            "statName": "스킬 사용 시간",
+            "before": "0.55",
+            "after": "0.70"
+          }
+        ]
+      },
+      {
+        "targetName": "브라이어",
+        "type": "champion",
+        "direction": "nerf",
+        "changes": [
+          {
+            "statName": "체력 증가량",
+            "before": "100",
+            "after": "95"
+          }
+        ]
+      },
+      {
+        "targetName": "이즈리얼",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": [
+          {
+            "statName": "주문력 계수",
+            "before": "주문력의 15%",
+            "after": "주문력의 40%"
+          },
+          {
+            "statName": "주문력 계수",
+            "before": "70~90%",
+            "after": "90%"
+          },
+          {
+            "statName": "주문력 계수",
+            "before": "90%",
+            "after": "110%"
+          },
+          {
+            "statName": "미니언 / 에픽 몬스터를 제외한 몬스터 대상 피해량",
+            "before": "175/275/375 (+추가 공격력의 50%) (+주문력의 45%)",
+            "after": "150/225/300 (+추가 공격력의 100%) (+주문력의 110%)"
+          }
+        ]
+      },
+      {
+        "targetName": "그라가스",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          {
+            "statName": "받는 피해량 감소",
+            "before": "10/12/14/16/18% (+주문력 100당 4%)",
+            "after": "10/14/18/22/26 (+주문력 100당 4%)"
+          }
+        ]
+      },
+      {
+        "targetName": "케넨",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": [
+          {
+            "statName": "[신규] 기본 지속 효과",
+            "before": "",
+            "after": "준비되면 기본 지속 효과가 첫 적중 시에만 적용되는 대신, 이제 공격 전체에 적중 시 효과가 적용됩니다."
+          },
+          {
+            "statName": "[신규] 기본 지속 효과 피해량",
+            "before": "",
+            "after": "이제 치명타가 적용되며 치명타로 140%(+추가 치명타 피해량의 40%)의 피해를 입힙니다."
+          },
+          {
+            "statName": "[신규] 공격 속도 증가 효과",
+            "before": "",
+            "after": "이제 치명타가 E - 번개 질주의 공격 속도 증가 효과 지속시간을 1초 늘리며, 기본 지속시간인 4초까지 증가합니다. 이 효과는 여러 번 발동할 수 있습니다."
+          }
+        ]
+      },
+      {
+        "targetName": "쉬바나",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": [
+          {
+            "statName": "공격 속도",
+            "before": "0.625",
+            "after": "0.638"
+          },
+          {
+            "statName": "공격 속도 계수",
+            "before": "0.69",
+            "after": "0.638"
+          },
+          {
+            "statName": "공격력 증가량",
+            "before": "3",
+            "after": "4"
+          },
+          {
+            "statName": "기본 지속 효과",
+            "before": "대상 최대 체력의 1% (+추가 공격력 100당 1.1%) (+주문력 100당 1.1%)",
+            "after": "대상 최대 체력의 1% (+추가 공격력 100당 1.1%)"
+          },
+          {
+            "statName": "타격 시 재사용 대기시간 감소",
+            "before": "1초",
+            "after": "0.5초"
+          },
+          {
+            "statName": "범위 물리 피해량",
+            "before": "10/15/20/25/30 (+공격력의 110%) (+주문력의 25%)",
+            "after": "10/15/20/25/30 (+공격력의 110%) (+주문력의 30%)"
+          },
+          {
+            "statName": "재사용 대기시간",
+            "before": "14/13.5/13/12.5/12초",
+            "after": "13/12/11/10/9초"
+          },
+          {
+            "statName": "보호막",
+            "before": "60/80/100/120/140 (+최대 체력의 5%)",
+            "after": "75/95/115/135/155 (+추가 체력의 12%)"
+          },
+          {
+            "statName": "피해량",
+            "before": "80/100/120/140/160 (+추가 공격력의 40%) (+주문력의 20%)",
+            "after": "80/100/120/140/160 (+주문력의 65%)"
+          },
+          {
+            "statName": "용 형상 체력 회복량",
+            "before": "75~214.71 (레벨에 따라) (+추가 공격력의 10%) (+주문력의 5%), (쉬바나가 잃은 체력에 따라 0%~100% 증가하여 최대 150~429.41 (레벨에 따라) (+추가 공격력의 20%) (+주문력의 10%) 체력 회복",
+            "after": "60~100 + 잃은 체력의 4~8% (레벨에 따라)"
+          },
+          {
+            "statName": "재사용 대기시간",
+            "before": "12/11.5/11/10.5/10초",
+            "after": "12/11/10/9/8초"
+          },
+          {
+            "statName": "마법 피해량",
+            "before": "80/110/140/170/200 (+추가 공격력의 35%) (+주문력의 70%)",
+            "after": "50/65/80/95/110 (+주문력의 60/65/70/75/80%) + 대상 최대 체력의 5%"
+          },
+          {
+            "statName": "동일한 대상에게 적용되는 연속 폭발 피해량",
+            "before": "50%",
+            "after": "40%"
+          },
+          {
+            "statName": "둔화율",
+            "before": "20/25/30/35/40%",
+            "after": "30%"
+          }
+        ]
+      },
+      {
+        "targetName": "탐 켄치",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          {
+            "statName": "회색 체력에서 체력으로 전환 비율",
+            "before": "45~100% (레벨에 따라)",
+            "after": "60~100% (레벨에 따라)"
+          },
+          {
+            "statName": "아군 집어삼키기 시 이동 속도",
+            "before": "3초 동안 40%",
+            "after": "3초 동안 60%"
+          }
+        ]
+      },
+      {
+        "targetName": "탈리야",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          {
+            "statName": "기본 피해량",
+            "before": "50/67.5/85/102.5/120",
+            "after": "55/72.5/90/107.5/125"
+          },
+          {
+            "statName": "몬스터 대상 추가 피해량",
+            "before": "23/28/33/38/43",
+            "after": "20/25/30/35/40"
+          }
+        ]
+      },
+      {
+        "targetName": "티모",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": [
+          {
+            "statName": "[신규] 최초 피해량 추가 공격력 계수",
+            "before": "",
+            "after": "추가 공격력의 10%"
+          },
+          {
+            "statName": "[신규] 지속 피해량 추가 공격력 계수",
+            "before": "",
+            "after": "4초 동안 추가 공격력의 30%"
+          }
+        ]
+      },
+      {
+        "targetName": "우디르",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": [
+          {
+            "statName": "첫 2회 기본 공격 시 추가 피해량",
+            "before": "대상 최대 체력의 3/4/5/6/7/8% (+추가 공격력 100당 4%)",
+            "after": "대상 최대 체력의 3/4/5/6/7/8% (+추가 공격력 100당 3.5%)"
+          },
+          {
+            "statName": "4초 동안 적중 시 추가 피해량",
+            "before": "5/13/21/29/37/45 (+추가 공격력의 25%)",
+            "after": "6/12/18/24/30/36 (+추가 공격력의 20%) (+추가 체력의 1~2%)"
+          },
+          {
+            "statName": "각성 첫 2회 기본 공격 시 추가 피해량",
+            "before": "추가로 대상 최대 체력의 2~4% (레벨에 따라) (+추가 공격력 100당 3%)",
+            "after": "추가로 대상 최대 체력의 2~4% (레벨에 따라) (+추가 공격력 100당 1.5%) (+추가 체력 1,000당 1%)"
+          },
+          {
+            "statName": "각성 연쇄 번개 반동당 피해량",
+            "before": "1.5~3% (레벨에 따라) (+주문력 100당 0.8%)",
+            "after": "1.5~3% (레벨에 따라) (+주문력 100당 0.6%)"
+          },
+          {
+            "statName": "[신규] 보호막 공격력 계수",
+            "before": "",
+            "after": "추가 공격력의 50%"
+          },
+          {
+            "statName": "[신규] 각성 보호막 공격력 계수",
+            "before": "",
+            "after": "추가 공격력의 100%"
+          },
+          {
+            "statName": "[신규] 각성 체력 회복량 공격력 계수",
+            "before": "",
+            "after": "추가 공격력의 50%"
+          },
+          {
+            "statName": "[신규] 이동 속도 공격력 계수",
+            "before": "",
+            "after": "추가 공격력 100당 이동 속도 5%"
+          },
+          {
+            "statName": "[신규] 각성 이동 속도 공격력 계수",
+            "before": "",
+            "after": "추가 공격력 100당 이동 속도 10%"
+          }
+        ]
+      },
+      {
+        "targetName": "워윅",
+        "type": "champion",
+        "direction": "buff",
+        "changes": [
+          {
+            "statName": "적중 시 피해량",
+            "before": "6/16/26/36/46",
+            "after": "6/18.25/30.5/42.75/55"
+          }
+        ]
+      },
+      {
+        "targetName": "신 짜오",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": [
+          {
+            "statName": "체력 회복량",
+            "before": "최대 체력의 3/4/5% (+주문력의 65%) (1/6/11레벨에서)",
+            "after": "최대 체력의 3/4/5% (+주문력의 50/65/90%) (1/6/11레벨에서)"
+          }
+        ]
+      },
+      {
+        "targetName": "제리",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": []
+      },
+      {
+        "targetName": "조이",
+        "type": "champion",
+        "direction": "adjust",
+        "changes": []
+      }
+    ],
+    "items": [
+      {
+        "targetName": "죽음불꽃 손길",
+        "type": "item",
+        "direction": "nerf",
+        "changes": [
+          {
+            "statName": "초당 적응형 피해량",
+            "before": "4~12 (레벨에 따라) + 추가 공격력의 8% + 주문력의 3%, 3초 후 피해량 100% 증가",
+            "after": "4~12 (레벨에 따라) + 추가 공격력의 7% + 주문력의 2.5%, 3초 후 피해량 75% 증가"
+          }
+        ]
+      }
+    ],
+    "systems": []
+  },
+  "arena": {
+    "champions": [],
+    "items": [],
+    "systems": []
+  }
+}

--- a/docs/sessions/2026-04-13-member-withdrawal.md
+++ b/docs/sessions/2026-04-13-member-withdrawal.md
@@ -1,0 +1,95 @@
+# Session: 회원 탈퇴 기능 구현
+
+**날짜**: 2026-04-13  
+**브랜치**: develop  
+
+---
+
+## 1. 사용자 요청
+
+회원 탈퇴 기능 구현 요청. 백엔드 API 스펙 제공:
+
+- `DELETE /api/members/me` — 인증 필요, 요청 바디 없음
+- 성공: `{ "result": "SUCCESS", "errorMessage": null, "data": null }`
+- 401: 인증 필요 / 토큰 만료
+- 400: 이미 탈퇴한 회원
+- 탈퇴 후 30일 이내 재가입 시도 시 403 에러
+
+### 구현 요구사항
+1. 마이페이지에 '회원 탈퇴' 버튼 추가
+2. 탈퇴 전 확인 모달 표시
+3. 탈퇴 성공 시 토큰 삭제 + 로그인 페이지 이동
+4. 로그인 시 403 에러 핸들링 (30일 재가입 제한 안내)
+
+---
+
+## 2. 설계 논의
+
+### UI 방식 선택
+- **모달 방식** (채택) — 오버레이 모달로 탈퇴 확인 표시. 파괴적 작업에 적합.
+- 인라인 확인 방식 — RiotLinkCard처럼 버튼 자리에 확인/취소 표시. 가볍지만 탈퇴에는 부적합.
+
+사용자 선택: **모달 방식**
+
+---
+
+## 3. 컨텍스트 탐색 결과
+
+### 참고한 기존 패턴
+- **모달**: `src/features/duo-register/ui/DuoRegisterModal.tsx` — overlay, ESC, 바깥클릭, body overflow
+- **Mutation 훅**: `src/features/nickname-edit/model/useNicknameEdit.ts` — useMutation + error state
+- **로그아웃**: `src/features/auth/model/useLogout.ts` — clearAuth + router.push
+- **Suspense 래핑**: `src/widgets/mypage-panel/ui/MypagePanel.tsx` — useSearchParams 감싸기
+- **인라인 에러**: `{error && <p className="text-sm text-error">...</p>}`
+
+### 주요 발견
+- 토스트/알림 시스템 없음 — 에러는 인라인 표시
+- API 클라이언트가 401 자동 처리 (토큰 갱신 + 리다이렉트)
+- OAuth 콜백에서 hash 기반 에러는 이미 처리됨 (`useGoogleLogin.ts` L25-29)
+- 로그인 페이지가 `?error=` 쿼리 파라미터를 아직 표시하지 않음
+
+---
+
+## 4. 구현 계획
+
+계획 파일: `plans/polished-crunching-octopus.md`
+
+### 구현 순서
+| 순서 | 파일 | 액션 |
+|------|------|------|
+| 1 | `src/entities/auth/api/authApi.ts` | 수정 — `withdrawMember` 추가 |
+| 2 | `src/entities/auth/index.ts` | 수정 — export 추가 |
+| 3 | `src/features/member-withdrawal/model/useMemberWithdrawal.ts` | 생성 |
+| 4 | `src/features/member-withdrawal/ui/WithdrawalConfirmModal.tsx` | 생성 |
+| 5 | `src/features/member-withdrawal/index.ts` | 생성 |
+| 6 | `src/widgets/mypage-panel/ui/AccountSection.tsx` | 수정 — 탈퇴 버튼 + 모달 |
+| 7 | `src/features/auth/model/useGoogleLogin.ts` | 수정 — 403 처리 |
+| 8 | `src/views/login/ui/LoginPageClient.tsx` | 수정 — 에러 배너 + Suspense |
+
+---
+
+## 5. 구현 완료
+
+### 수정된 파일 (5개)
+- `src/entities/auth/api/authApi.ts` — `withdrawMember()` API 함수 추가
+- `src/entities/auth/index.ts` — barrel export에 `withdrawMember` 추가
+- `src/widgets/mypage-panel/ui/AccountSection.tsx` — 탈퇴 버튼 + 확인 모달 연결
+- `src/features/auth/model/useGoogleLogin.ts` — `getMyProfile()` 403 에러 → 로그인 페이지 에러 표시
+- `src/views/login/ui/LoginPageClient.tsx` — `?error=` 쿼리 파라미터 읽어 에러 배너 표시 + Suspense 래핑
+
+### 생성된 파일 (3개)
+- `src/features/member-withdrawal/model/useMemberWithdrawal.ts` — 탈퇴 mutation 훅
+- `src/features/member-withdrawal/ui/WithdrawalConfirmModal.tsx` — 확인 모달 (경고 + 취소/탈퇴 버튼)
+- `src/features/member-withdrawal/index.ts` — barrel export
+
+### 동작 흐름
+1. 마이페이지 → "회원 탈퇴" 클릭 → 경고 모달 표시
+2. "탈퇴하기" 클릭 → `DELETE /api/members/me` 호출 → 성공 시 인증 초기화 + 로그인 페이지 이동
+3. 탈퇴 후 30일 내 재로그인 시 → 서버 403 → 로그인 페이지에 에러 배너 표시
+
+---
+
+## 6. 검증 결과
+
+- `pnpm build` — 성공 (에러 없음)
+- `pnpm lint` — 경고 2개 (기존 DuoRegisterModal의 react-hook-form 관련, 이번 변경과 무관)


### PR DESCRIPTION
## 배경

로컬 워킹트리에 untracked 로만 존재하던 파일들입니다. 로컬 소스 정리 전에 유실을 막기 위해 PR 로 올립니다.

## 변경

**1) `docs/patch/` 패치 데이터 (26.7~26.9)**
- `26.7.html`, `26.7.json`, `26.8.json`, `26.9.json`
- `26.1`~`26.6` 은 이미 추적 중이며 그 연속입니다. 이 4개만 커밋되지 않아 데이터가 끊겨 있었습니다.
- `26.8` / `26.9` 는 로컬에 html 이 없어 json 만 추가했습니다.

**2) `docs/sessions/2026-04-13-member-withdrawal.md`**
- 원래 루트 `messages/` 에 있던 파일입니다. Next.js 에서 `messages/` 는 next-intl 번역 디렉터리 관례와 혼동되므로 `docs/sessions/` 로 옮겨 커밋했습니다. 불필요하면 이 커밋만 빼셔도 됩니다.

앱 코드가 `docs/patch` 를 직접 읽지는 않으며(보관용 데이터), 코드 변경은 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)