### PR TITLE
fix: 프로필 갱신 쿨다운 카운트다운 hydration mismatch 수정

### DIFF
--- a/src/widgets/summoner-profile/ui/ProfileSection.tsx
+++ b/src/widgets/summoner-profile/ui/ProfileSection.tsx
@@ -46,7 +46,9 @@ export default function ProfileSection({
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const pollingStartTimeRef = useRef<number | null>(null);
   const [refreshError, setRefreshError] = useState<string | null>(null);
-  const [now, setNow] = useState(() => Date.now());
+  // SSR/hydration 첫 렌더에서는 시간 계산을 하지 않기 위해 null로 시작한다.
+  // 실제 시간 카운트는 마운트 후 클라이언트에서만 진행 (아래 useEffect에서 setNow).
+  const [now, setNow] = useState<number | null>(null);
 
   // 컴포넌트 언마운트 시 폴링 정리
   useEffect(() => {
@@ -59,10 +61,13 @@ export default function ProfileSection({
   }, []);
 
   // 쿨다운 (2분) 계산 - 서버의 lastRevisionDateTime 기준
-  // lastRevisionClickDateTime이 있을 때만 1초마다 now를 갱신해 재계산을 트리거한다.
+  // lastRevisionClickDateTime이 있을 때만 마운트 직후 now를 세팅하고
+  // 1초마다 갱신해 재계산을 트리거한다. (실제 시간 카운트는 클라이언트 사이드에서만)
   useEffect(() => {
     if (!profileData?.lastRevisionClickDateTime) return;
-    const interval = setInterval(() => setNow(Date.now()), 1000);
+    const updateNow = () => setNow(Date.now());
+    updateNow(); // 마운트 직후 즉시 1회 계산
+    const interval = setInterval(updateNow, 1000);
     return () => clearInterval(interval);
   }, [profileData?.lastRevisionClickDateTime]);
 
@@ -71,7 +76,8 @@ export default function ProfileSection({
     cooldownInfo: { remainingSeconds: number } | null;
     elapsedText: string | null;
   }>(() => {
-    if (!profileData?.lastRevisionClickDateTime) {
+    // now === null 이면 아직 마운트 전(서버/hydration 첫 렌더)이므로 계산하지 않는다.
+    if (!profileData?.lastRevisionClickDateTime || now === null) {
       return { cooldownInfo: null, elapsedText: null };
     }
 


### PR DESCRIPTION
## 문제

소환사 페이지(`/summoners/[region]/[summonerName]`)에서 다음 hydration 에러 발생:

> Hydration failed because the server rendered text didn't match the client.
> `+ 1분 51초 후 재시도` (client) / `- 1분 52초 후 재시도` (server)

## 원인

`ProfileSection.tsx`의
```tsx
const [now, setNow] = useState(() => Date.now());
```
이 `now`를 `Date.now()`로 초기화하는데, 이 값은 **서버 렌더 시점**과 **클라이언트 hydration 시점**에 각각 평가된다. 두 시점 사이에 (JS 다운로드/파싱 등으로) 약 1초가 흐르면서 남은 쿨다운 초 계산값이 달라지고, 그 값으로 렌더되는 텍스트가 서버("1분 52초")와 클라이언트("1분 51초")에서 어긋나 mismatch가 발생.

> 참고: 이 버그는 `badd088 refactor: 불필요한 useState/useEffect 제거` 리팩터링에서 `useEffect` 기반 계산을 렌더 중 `useMemo` + `useState(() => Date.now())`로 바꾸며 유입됨. (base가 `develop`인 이유)

## 수정

시간 카운트는 **서버가 아니라 클라이언트에서만** 진행하도록 변경:

- `now` 초기값을 `null`로 → 서버/hydration 첫 렌더에서는 시간 계산을 하지 않음
- `useMemo`에서 `now === null`이면 `cooldownInfo`/`elapsedText`를 `null` 반환 → 서버와 클라 첫 렌더가 "표시 없음"으로 일치
- 마운트 후 `useEffect`에서만 `setNow`로 시간 계산 시작 (즉시 1회 + 1초 간격)
- `setState` 직접 호출은 기존 `IngameHeader`와 동일하게 헬퍼 함수(`updateNow`)로 감싸 `react-hooks/set-state-in-effect` 룰 준수

`elapsedText`("마지막 갱신") 역시 클라이언트 시간 의존이라 함께 client-only로 바뀌어 잠재적 mismatch까지 제거됨.

## 검증

- `npx tsc --noEmit` 통과
- `npx eslint` 통과 (set-state-in-effect 룰 위반 없음)
- lint-staged pre-commit 훅 통과

## 참고

- 이 접근은 동일 문제(setInterval 카운트다운 + hydration)를 이미 해결한 `IngameHeader.tsx` 패턴과 일치.
- 브랜치명에 MP 번호 미포함 (해당 티켓 번호 미지정). 필요 시 알려주시면 반영하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)