### PR TITLE
feat: 커뮤니티 신규 기능용 공통 Toast/Modal 인프라 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "19.2.4",
     "react-error-boundary": "^6.1.1",
     "react-hook-form": "^7.71.2",
+    "sonner": "^2.0.7",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-hook-form:
         specifier: ^7.71.2
         version: 7.71.2(react@19.2.4)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1996,6 +1999,12 @@ packages:
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4277,6 +4286,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { QueryProvider } from "@/shared/providers/QueryProvider";
 import GameDataLoader from "./GameDataLoader";
 import { ThemeProvider } from "@/shared/providers/ThemeProvider";
+import { Toaster } from "@/shared/ui/toast";
 import type { Metadata } from "next";
 import { Geist } from "next/font/google";
 import "./globals.css";
@@ -38,6 +39,7 @@ export default function RootLayout({
           <ThemeProvider>
             <GameDataLoader />
             {children}
+            <Toaster />
           </ThemeProvider>
         </QueryProvider>
       </body>

--- a/src/shared/ui/modal/ConfirmModal.tsx
+++ b/src/shared/ui/modal/ConfirmModal.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { Modal, type ModalSize } from "./Modal";
+
+export interface ConfirmModalProps {
+  open: boolean;
+  /** 모달 제목 */
+  title: string;
+  /** 본문. 문자열 대신 노드도 받는다. */
+  description?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** danger 는 파괴적 동작(삭제·탈퇴)용 */
+  variant?: "default" | "danger";
+  /** 처리 중. true 면 버튼이 잠기고 배경/Escape 로 닫히지 않는다. */
+  loading?: boolean;
+  size?: ModalSize;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+/**
+ * 브라우저 기본 `confirm()` 을 대체하는 확인 모달.
+ *
+ * `confirm()` 은 메인 스레드를 막고 스타일을 입힐 수 없으며 모바일에서 도메인이 노출된다.
+ */
+export function ConfirmModal({
+  open,
+  title,
+  description,
+  confirmLabel = "확인",
+  cancelLabel = "취소",
+  variant = "default",
+  loading = false,
+  size = "sm",
+  onConfirm,
+  onClose,
+}: ConfirmModalProps) {
+  const isDanger = variant === "danger";
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={title}
+      size={size}
+      showCloseButton={false}
+      closeOnBackdrop={!loading}
+      closeOnEscape={!loading}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={loading}
+            className="flex-1 py-2.5 bg-surface-4 border border-divider text-on-surface-medium rounded-lg text-sm font-medium hover:bg-surface-1 transition-colors disabled:opacity-50"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={loading}
+            className={`flex-1 py-2.5 rounded-lg text-sm font-medium text-white transition-colors disabled:opacity-50 ${
+              isDanger
+                ? "bg-error hover:bg-error/90"
+                : "bg-primary hover:bg-primary/90"
+            }`}
+          >
+            {loading ? "처리 중..." : confirmLabel}
+          </button>
+        </>
+      }
+    >
+      {description &&
+        (isDanger ? (
+          <div className="flex items-start gap-3 p-4 bg-error/10 border border-error/20 rounded-lg">
+            <AlertTriangle className="w-5 h-5 text-error shrink-0 mt-0.5" />
+            <div className="text-sm text-on-surface-medium leading-relaxed">
+              {description}
+            </div>
+          </div>
+        ) : (
+          <div className="text-sm text-on-surface-medium leading-relaxed">
+            {description}
+          </div>
+        ))}
+    </Modal>
+  );
+}

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useSyncExternalStore,
+} from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+
+export type ModalSize = "sm" | "md" | "lg" | "xl";
+
+const SIZE_CLASS: Record<ModalSize, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-2xl",
+};
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+/**
+ * 열려 있는 모달 스택.
+ *
+ * 모달은 겹칠 수 있다 (예: 상세 모달 안에서 삭제 확인 모달). 스택이 없으면
+ * (1) Escape 한 번에 모달이 전부 닫히고
+ * (2) 안쪽 모달을 닫는 순간 body 스크롤 잠금이 풀려 바깥 모달 뒤 페이지가 스크롤된다.
+ * 최상단 id 만 Escape 를 처리하고, 스택이 완전히 빌 때만 스크롤을 되돌린다.
+ */
+const openStack: string[] = [];
+let previousBodyOverflow = "";
+
+function pushModal(id: string) {
+  if (openStack.length === 0) {
+    previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  }
+  openStack.push(id);
+}
+
+function popModal(id: string) {
+  const index = openStack.lastIndexOf(id);
+  if (index !== -1) openStack.splice(index, 1);
+  if (openStack.length === 0) {
+    document.body.style.overflow = previousBodyOverflow;
+  }
+}
+
+const noopSubscribe = () => () => {};
+
+/**
+ * 클라이언트에서 마운트가 끝났는지. `createPortal` 의 대상인 document 가
+ * 서버에는 없어서 필요하다.
+ *
+ * effect + setState 대신 useSyncExternalStore 를 쓰는 이유:
+ * 하이드레이션 중에는 getServerSnapshot(false)이 쓰여 서버 결과와 일치하고,
+ * 하이드레이션 이후에 getSnapshot(true)으로 넘어간다. 불일치도, 추가 렌더 경고도 없다.
+ */
+function useHasMounted() {
+  return useSyncExternalStore(
+    noopSubscribe,
+    () => true,
+    () => false,
+  );
+}
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: React.ReactNode;
+  /** 헤더 우측 X 버튼 노출 여부 */
+  showCloseButton?: boolean;
+  /** 배경 클릭으로 닫기. 처리 중에는 false 로 내려 닫기를 막는다. */
+  closeOnBackdrop?: boolean;
+  /** Escape 로 닫기. 처리 중에는 false 로 내려 닫기를 막는다. */
+  closeOnEscape?: boolean;
+  size?: ModalSize;
+  /** 푸터 영역 (주로 액션 버튼) */
+  footer?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+/**
+ * 공용 모달 셸. 오버레이·스크롤 잠금·Escape·포커스 관리만 담당하고
+ * 내용은 children 이 채운다.
+ */
+export function Modal({
+  open,
+  onClose,
+  title,
+  showCloseButton = true,
+  closeOnBackdrop = true,
+  closeOnEscape = true,
+  size = "md",
+  footer,
+  children,
+}: ModalProps) {
+  const instanceId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const mounted = useHasMounted();
+
+  useEffect(() => {
+    if (!open) return;
+    pushModal(instanceId);
+    return () => popModal(instanceId);
+  }, [open, instanceId]);
+
+  // 열릴 때 포커스를 모달 안으로 옮기고, 닫힐 때 원래 위치로 되돌린다.
+  useEffect(() => {
+    if (!open) return;
+    restoreFocusRef.current = document.activeElement as HTMLElement | null;
+    const panel = panelRef.current;
+    const first = panel?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    (first ?? panel)?.focus();
+    return () => restoreFocusRef.current?.focus?.();
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        if (!closeOnEscape) return;
+        // 겹쳐 있을 때 최상단 모달만 반응한다.
+        if (openStack[openStack.length - 1] !== instanceId) return;
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = Array.from(
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => el.offsetParent !== null);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    },
+    [closeOnEscape, instanceId, onClose],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, handleKeyDown]);
+
+  if (!open || !mounted) return null;
+
+  const labelId = title ? `${instanceId}-title` : undefined;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center"
+      onMouseDown={(e) => {
+        // click 이 아니라 mousedown 기준. 모달 안에서 드래그를 시작해 배경에서 놓으면
+        // click 의 target 이 배경이 되어 의도치 않게 닫힌다.
+        if (closeOnBackdrop && e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelId}
+        tabIndex={-1}
+        className={`bg-surface-4 rounded-lg border border-divider w-full ${SIZE_CLASS[size]} mx-4 max-h-[90vh] overflow-y-auto p-6 outline-none`}
+      >
+        {(title || showCloseButton) && (
+          <div className="flex items-center justify-between mb-6">
+            {title ? (
+              <h2 id={labelId} className="text-lg font-bold text-on-surface">
+                {title}
+              </h2>
+            ) : (
+              <span />
+            )}
+            {showCloseButton && (
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="닫기"
+                className="text-on-surface-disabled hover:text-on-surface transition-colors disabled:opacity-50"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            )}
+          </div>
+        )}
+
+        {children}
+
+        {footer && <div className="flex gap-3 mt-6">{footer}</div>}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/shared/ui/modal/index.ts
+++ b/src/shared/ui/modal/index.ts
@@ -1,0 +1,4 @@
+export { Modal } from "./Modal";
+export type { ModalProps, ModalSize } from "./Modal";
+export { ConfirmModal } from "./ConfirmModal";
+export type { ConfirmModalProps } from "./ConfirmModal";

--- a/src/shared/ui/toast/Toaster.tsx
+++ b/src/shared/ui/toast/Toaster.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Toaster as SonnerToaster } from "sonner";
+
+/**
+ * 앱 전역 토스트 컨테이너. `app/layout.tsx` 에 한 번만 마운트한다.
+ *
+ * 색은 sonner 의 CSS 변수를 디자인 토큰으로 덮어써서 맞춘다.
+ * 토큰(`--color-surface-4` 등)이 루트의 `.dark`/`.light` 클래스를 따라 바뀌므로,
+ * 테마 스토어를 구독하지 않아도 라이트/다크가 자동으로 따라온다.
+ * (shared 레이어는 features/theme-toggle 을 import 할 수 없다 — FSD 의존 방향)
+ */
+export function Toaster() {
+  return (
+    <SonnerToaster
+      position="top-center"
+      duration={3000}
+      closeButton
+      richColors
+      style={
+        {
+          "--normal-bg": "var(--color-surface-4)",
+          "--normal-text": "var(--color-on-surface)",
+          "--normal-border": "var(--color-divider)",
+          "--success-bg": "var(--color-surface-4)",
+          "--success-text": "var(--color-success)",
+          "--success-border": "var(--color-divider)",
+          "--error-bg": "var(--color-surface-4)",
+          "--error-text": "var(--color-error)",
+          "--error-border": "var(--color-divider)",
+          "--warning-bg": "var(--color-surface-4)",
+          "--warning-text": "var(--color-warning)",
+          "--warning-border": "var(--color-divider)",
+        } as React.CSSProperties
+      }
+    />
+  );
+}

--- a/src/shared/ui/toast/index.ts
+++ b/src/shared/ui/toast/index.ts
@@ -1,0 +1,7 @@
+export { Toaster } from "./Toaster";
+
+/**
+ * 호출부는 sonner 를 직접 import 하지 않고 이 seam 을 통해 쓴다.
+ * 토스트 라이브러리를 교체할 때 바꿀 지점이 여기 하나로 모인다.
+ */
+export { toast } from "sonner";

--- a/src/widgets/community-detail/ui/CommentSection.tsx
+++ b/src/widgets/community-detail/ui/CommentSection.tsx
@@ -10,7 +10,10 @@ import {
 } from "@/entities/community";
 import { useAuthStore } from "@/entities/auth";
 import { CommentForm, CommentItem } from "@/features/community-comment";
+import { ConfirmModal } from "@/shared/ui/modal";
+import { toast } from "@/shared/ui/toast";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 interface CommentSectionProps {
   postId: number;
@@ -26,6 +29,7 @@ export default function CommentSection({ postId, commentCount }: CommentSectionP
   const deleteMutation = useDeleteComment(postId);
   const voteMutation = useVote(postId);
   const removeVoteMutation = useRemoveVote(postId);
+  const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
 
   const handleCreate = (content: string) => {
     if (!user) {
@@ -48,9 +52,15 @@ export default function CommentSection({ postId, commentCount }: CommentSectionP
   };
 
   const handleDelete = (commentId: number) => {
-    if (confirm("댓글을 삭제하시겠습니까?")) {
-      deleteMutation.mutate(commentId);
-    }
+    setPendingDeleteId(commentId);
+  };
+
+  const confirmDelete = () => {
+    if (pendingDeleteId === null) return;
+    deleteMutation.mutate(pendingDeleteId, {
+      onSuccess: () => setPendingDeleteId(null),
+      onError: () => toast.error("댓글 삭제에 실패했습니다."),
+    });
   };
 
   const handleVote = (targetId: number, voteType: "UPVOTE" | "DOWNVOTE") => {
@@ -98,6 +108,17 @@ export default function CommentSection({ postId, commentCount }: CommentSectionP
           아직 댓글이 없습니다. 첫 댓글을 작성해보세요!
         </div>
       )}
+
+      <ConfirmModal
+        open={pendingDeleteId !== null}
+        title="댓글 삭제"
+        description="이 댓글을 삭제하시겠습니까? 삭제한 댓글은 되돌릴 수 없습니다."
+        confirmLabel="삭제"
+        variant="danger"
+        loading={deleteMutation.isPending}
+        onConfirm={confirmDelete}
+        onClose={() => setPendingDeleteId(null)}
+      />
     </div>
   );
 }

--- a/src/widgets/community-detail/ui/PostDetailPanel.tsx
+++ b/src/widgets/community-detail/ui/PostDetailPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { ArrowLeft, Pencil, Trash2 } from "lucide-react";
 import {
   usePostDetail,
@@ -12,6 +13,8 @@ import {
 import type { VoteType } from "@/entities/community";
 import { useAuthStore } from "@/entities/auth";
 import { VoteButtons } from "@/shared/ui/vote-buttons";
+import { ConfirmModal } from "@/shared/ui/modal";
+import { toast } from "@/shared/ui/toast";
 import { formatDate } from "@/shared/lib/date";
 import CommentSection from "./CommentSection";
 
@@ -24,6 +27,7 @@ export default function PostDetailPanel({ postId }: PostDetailPanelProps) {
   const user = useAuthStore((s) => s.user);
   const { data: post, isLoading, error } = usePostDetail(postId);
   const deleteMutation = useDeletePost();
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const voteMutation = useVote(postId);
   const removeVoteMutation = useRemoveVote(postId);
 
@@ -44,13 +48,15 @@ export default function PostDetailPanel({ postId }: PostDetailPanelProps) {
     }
   };
 
-  const handleDelete = () => {
+  const confirmDelete = () => {
     if (!post) return;
-    if (confirm("게시글을 삭제하시겠습니까?")) {
-      deleteMutation.mutate(post.id, {
-        onSuccess: () => router.push("/community"),
-      });
-    }
+    deleteMutation.mutate(post.id, {
+      onSuccess: () => {
+        setDeleteOpen(false);
+        router.push("/community");
+      },
+      onError: () => toast.error("게시글 삭제에 실패했습니다."),
+    });
   };
 
   if (isLoading) {
@@ -119,7 +125,7 @@ export default function PostDetailPanel({ postId }: PostDetailPanelProps) {
               </button>
               <button
                 type="button"
-                onClick={handleDelete}
+                onClick={() => setDeleteOpen(true)}
                 disabled={deleteMutation.isPending}
                 className="flex items-center gap-1 text-xs text-on-surface-disabled hover:text-red-400 transition-colors disabled:opacity-50 cursor-pointer"
               >
@@ -148,6 +154,17 @@ export default function PostDetailPanel({ postId }: PostDetailPanelProps) {
       <div className="bg-surface-1 border border-divider rounded-lg p-6">
         <CommentSection postId={post.id} commentCount={post.commentCount} />
       </div>
+
+      <ConfirmModal
+        open={deleteOpen}
+        title="게시글 삭제"
+        description="이 게시글을 삭제하시겠습니까? 삭제한 게시글은 되돌릴 수 없습니다."
+        confirmLabel="삭제"
+        variant="danger"
+        loading={deleteMutation.isPending}
+        onConfirm={confirmDelete}
+        onClose={() => setDeleteOpen(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
커뮤니티 신규 기능(북마크·신고·이미지 첨부·알림) 설계의 **STEP 0 — 공통 선행 작업**입니다.
네 기능이 모두 토스트와 모달을 쓰기 때문에, 각자 만들어 네 벌이 되기 전에 먼저 공용화합니다.

## 변경

### 1. Toast — `sonner` 도입 (`shared/ui/toast`)
- `Toaster` 를 `app/layout.tsx` 에 한 번 마운트
- 색은 sonner 의 CSS 변수(`--normal-bg` 등)를 디자인 토큰으로 덮어써서 맞춥니다.
  토큰이 루트의 `.dark`/`.light` 를 따라 바뀌므로 **테마 스토어를 구독하지 않아도 라이트/다크가 자동으로 따라옵니다.**
  `shared` 레이어는 `features/theme-toggle` 을 import 할 수 없어서(FSD 의존 방향) 이 방식이 필요했습니다.
- `toast` 를 `shared/ui/toast` 에서 재수출합니다. 호출부가 `sonner` 를 직접 import 하지 않게 해서, 라이브러리를 바꿀 때 고칠 지점을 한 곳으로 모읍니다.

### 2. Modal — `shared/ui/modal`
기존 모달 4개(`WithdrawalConfirmModal`, `DuoRegisterModal`, `DuoRequestModal`, `DuoPostDetailModal`)는 오버레이·ESC·스크롤 잠금·백드롭 클릭이 **거의 그대로 복제**돼 있고, 넷 다 `role="dialog"` 와 포커스 관리가 없습니다. 공용 셸은 그 결함까지 함께 걷어냅니다.

기존 구현 대비 추가된 것:
- **포털** — `createPortal` 로 `document.body` 에 렌더. 조상의 `overflow`/`transform` 에 잘리거나 z-index 가 갇히지 않습니다.
- **`role="dialog"` + `aria-modal` + `aria-labelledby`**, 포커스 트랩(Tab 순환), 닫힐 때 원래 위치로 포커스 복원
- **모달 중첩 처리** — 열린 모달 스택을 두어 ① Escape 는 최상단 모달만 처리하고 ② 스택이 완전히 빌 때만 body 스크롤을 되돌립니다. 스택이 없으면 안쪽 모달을 닫는 순간 바깥 모달 뒤 페이지가 스크롤됩니다. 실제로 `DuoPostDetailModal` 안에 삭제 확인이 들어 있어 가상의 상황이 아닙니다.
- **백드롭 닫기를 `mousedown` 기준으로** — `click` 기준이면 모달 안에서 드래그를 시작해 배경에서 손을 떼는 순간 `target` 이 배경이 되어 모달이 의도치 않게 닫힙니다.

### 3. 첫 소비자 — 커뮤니티의 네이티브 `confirm()` 2곳 교체
`CommentSection`(댓글 삭제), `PostDetailPanel`(게시글 삭제)을 `ConfirmModal` 로 바꾸고, 삭제 실패 시 토스트로 알립니다. 기존에는 실패해도 **아무 표시가 없었습니다.**

## 범위 밖 (의도적)
- **기존 모달 4개는 마이그레이션하지 않았습니다.** 이 PR 의 목적은 셸을 세우는 것이고, 동작하는 화면 4개를 같이 건드리면 회귀 위험과 리뷰 범위가 함께 커집니다.
- `DuoPostDetailModal:55` 의 `confirm()` 은 듀오 범위라 남겨 뒀습니다.

## 검증
- `npx tsc --noEmit` 통과
- `pnpm lint` — **0 errors** (남은 warning 5건은 이 PR 이 건드리지 않은 파일의 기존 것)
- `pnpm build` 성공 (18개 정적 페이지 생성)
- ⚠️ **런타임 수동 확인은 아직입니다** — 백엔드가 필요해서 삭제 플로우를 실제로 눌러보지 못했습니다. 머지 전 확인 권장:
  - 댓글/게시글 삭제 확인 모달이 뜨고 실제로 삭제되는지
  - 삭제 실패 시 토스트가 뜨는지
  - 라이트/다크 전환 시 토스트 색이 따라오는지
  - Escape·백드롭 클릭·Tab 순환

## 참고
Linear MP 번호를 발급받지 못해 브랜치·커밋에 `MP-` 키가 없습니다. 최근 커밋들(`refactor/remove-unnecessary-state-effect` 등)의 관행을 따랐습니다. 번호가 있다면 알려주시면 정리하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCTseN4Lk5uXhMTkJZjWVM