### PR TITLE
feat: 커뮤니티 북마크 UI

### DIFF
--- a/src/entities/community/api/bookmarkApi.ts
+++ b/src/entities/community/api/bookmarkApi.ts
@@ -1,0 +1,21 @@
+import { apiClient } from "@/shared/api/client";
+import type { ApiResponse } from "@/shared/api/types";
+import type { PostListResponse } from "../types";
+
+export async function addBookmark(postId: number): Promise<void> {
+  await apiClient.post("/community/bookmarks", { postId });
+}
+
+export async function removeBookmark(postId: number): Promise<void> {
+  await apiClient.delete(`/community/bookmarks/${postId}`);
+}
+
+export async function getMyBookmarks(
+  page: number = 0
+): Promise<PostListResponse> {
+  const response = await apiClient.get<ApiResponse<PostListResponse>>(
+    "/community/me/bookmarks",
+    { params: { page } }
+  );
+  return response.data.data;
+}

--- a/src/entities/community/api/bookmarkApi.ts
+++ b/src/entities/community/api/bookmarkApi.ts
@@ -2,12 +2,35 @@ import { apiClient } from "@/shared/api/client";
 import type { ApiResponse } from "@/shared/api/types";
 import type { PostListResponse } from "../types";
 
+function statusOf(error: unknown): number | undefined {
+  if (typeof error === "object" && error !== null && "response" in error) {
+    return (error as { response?: { status?: number } }).response?.status;
+  }
+  return undefined;
+}
+
+/**
+ * 이 파일은 entities API 중 유일하게 예외를 흡수한다.
+ *
+ * 서버는 중복 북마크에 409, 없는 북마크 해제에 404 를 준다. 둘 다 "요청이 실패했다"가
+ * 아니라 "원하는 상태에 이미 도달해 있다"는 뜻이다. 토글에서는 성공과 구분할 이유가
+ * 없고, 구분하면 더블클릭처럼 흔한 조작이 곧바로 에러로 보인다.
+ * 여기서 접어서 add/remove 를 멱등하게 만든다.
+ */
 export async function addBookmark(postId: number): Promise<void> {
-  await apiClient.post("/community/bookmarks", { postId });
+  try {
+    await apiClient.post("/community/bookmarks", { postId });
+  } catch (error) {
+    if (statusOf(error) !== 409) throw error;
+  }
 }
 
 export async function removeBookmark(postId: number): Promise<void> {
-  await apiClient.delete(`/community/bookmarks/${postId}`);
+  try {
+    await apiClient.delete(`/community/bookmarks/${postId}`);
+  } catch (error) {
+    if (statusOf(error) !== 404) throw error;
+  }
 }
 
 export async function getMyBookmarks(

--- a/src/entities/community/index.ts
+++ b/src/entities/community/index.ts
@@ -39,4 +39,6 @@ export { useCreateComment, useUpdateComment, useDeleteComment } from "./model/us
 export { useVote, useRemoveVote } from "./model/useVoteMutation";
 export { useBookmarkToggle } from "./model/useBookmarkMutation";
 export { useMyBookmarks } from "./model/useMyBookmarks";
-export { bookmarkKeys } from "./model/bookmarkKeys";
+export { bookmarkKeys, postDetailKey } from "./model/bookmarkKeys";
+export { useRemoveBookmark } from "./model/useBookmarkMutation";
+export { default as PostCard } from "./ui/PostCard";

--- a/src/entities/community/index.ts
+++ b/src/entities/community/index.ts
@@ -29,6 +29,7 @@ export {
 export { getPosts, getPostDetail, createPost, updatePost, deletePost, searchPosts, getMyPosts } from "./api/communityApi";
 export { getComments, createComment, updateComment, deleteComment } from "./api/commentApi";
 export { vote, removeVote } from "./api/voteApi";
+export { addBookmark, removeBookmark, getMyBookmarks } from "./api/bookmarkApi";
 
 export { usePosts, useSearchPosts, useMyPosts } from "./model/usePosts";
 export { usePostDetail } from "./model/usePostDetail";
@@ -36,3 +37,6 @@ export { useComments } from "./model/useComments";
 export { useCreatePost, useUpdatePost, useDeletePost } from "./model/usePostMutations";
 export { useCreateComment, useUpdateComment, useDeleteComment } from "./model/useCommentMutations";
 export { useVote, useRemoveVote } from "./model/useVoteMutation";
+export { useBookmarkToggle } from "./model/useBookmarkMutation";
+export { useMyBookmarks } from "./model/useMyBookmarks";
+export { bookmarkKeys } from "./model/bookmarkKeys";

--- a/src/entities/community/model/bookmarkKeys.ts
+++ b/src/entities/community/model/bookmarkKeys.ts
@@ -1,0 +1,14 @@
+/**
+ * 북마크 쿼리 키. duoKeys 와 같은 factory 형태다.
+ *
+ * 기존 community 쿼리들은 인라인 문자열 배열을 쓰고 있어서, 그쪽 캐시를
+ * invalidate 할 때는 리터럴을 그대로 맞춰 써야 한다 (communityKeys 전면 정리는 별건).
+ */
+export const bookmarkKeys = {
+  all: ["community", "bookmarks"] as const,
+  myList: (page: number) => [...bookmarkKeys.all, "my", page] as const,
+};
+
+/** 게시글 상세 캐시 키 — usePostDetail.ts 의 리터럴과 반드시 같아야 한다. */
+export const postDetailKey = (postId: number) =>
+  ["community", "post", postId] as const;

--- a/src/entities/community/model/useBookmarkMutation.ts
+++ b/src/entities/community/model/useBookmarkMutation.ts
@@ -3,73 +3,118 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef } from "react";
 import { useDebouncedCallback } from "@/shared/lib/useDebouncedCallback";
-import { toast } from "@/shared/ui/toast";
 import { addBookmark, removeBookmark } from "../api/bookmarkApi";
 import type { Post } from "../types";
 import { bookmarkKeys, postDetailKey } from "./bookmarkKeys";
 
 const TOGGLE_DEBOUNCE_MS = 400;
 
+interface UseBookmarkToggleOptions {
+  /** 실패를 사용자에게 알리는 방법은 호출부가 정한다 (entities 는 UI 를 모른다). */
+  onError?: () => void;
+}
+
 /**
  * 북마크 토글.
  *
  * 이 리포에서 낙관적 업데이트를 쓰는 첫 훅이다. 다른 뮤테이션은 전부
- * `onSuccess → invalidateQueries` 한 가지인데 북마크만 다르게 가는 이유:
- * 토글은 누른 즉시 반응해야 하고, 왕복을 기다리면 연타 시 버튼이 제멋대로 깜빡인다.
+ * `onSuccess → invalidateQueries` 한 가지인데 북마크만 다르게 가는 이유는 토글이라서다.
+ * 누른 즉시 반응해야 하고, 왕복을 기다리면 연타 시 버튼이 제멋대로 깜빡인다.
  *
- * 낙관적 갱신을 `onMutate` 가 아니라 클릭 시점에 하는 이유도 같다.
- * 디바운스 때문에 `onMutate` 는 400ms 뒤에나 실행되어 화면이 그만큼 밀린다.
+ * 세 가지를 의도적으로 하지 않는다.
+ *
+ * 1. **상세 캐시를 invalidate 하지 않는다.** 응답이 오는 시점엔 이미 다음 클릭의
+ *    낙관적 값이 화면에 있을 수 있고, refetch 가 그걸 덮으면 버튼이 되돌아갔다 온다
+ *    (= 이 훅이 막으려던 깜빡임을 스스로 만든다). 확정값을 직접 써넣는다.
+ * 2. **Post 전체를 스냅샷하지 않는다.** 통짜로 되돌리면 그 사이 바뀐 추천 수·조회 수까지
+ *    같이 되감긴다. 되돌릴 대상은 boolean 하나다.
+ * 3. **서버 상태와 같은 요청은 보내지 않는다.** 짝수 번 연타하면 최종 의도가 원래
+ *    상태와 같은데, 그걸 그대로 보내면 서버는 409/404 를 준다.
  */
-export function useBookmarkToggle(postId: number) {
+export function useBookmarkToggle(
+  postId: number,
+  options?: UseBookmarkToggleOptions,
+) {
   const queryClient = useQueryClient();
   const queryKey = useMemo(() => postDetailKey(postId), [postId]);
 
-  // 연타 한 묶음에서 "첫 클릭 직전" 상태만 보관한다. 매 클릭마다 덮어쓰면
-  // 롤백 대상이 이미 낙관적으로 바뀐 값이 되어 원래대로 못 돌아간다.
-  const rollbackRef = useRef<Post | undefined>(undefined);
+  // 서버가 확인해준 마지막 상태. 낙관적 값과 반드시 구분해서 들고 있어야
+  // 보낼 필요 없는 요청을 걸러내고, 실패했을 때 되돌릴 곳을 안다.
+  const serverStateRef = useRef<boolean | null>(null);
+  // 아직 발사되지 않은 클릭이 남아 있는지. 남아 있으면 서버 응답으로
+  // 화면을 건드리면 안 된다 — 더 최신 의도가 이미 화면에 있다.
+  const hasPendingRef = useRef(false);
+
+  const writeBookmarked = useCallback(
+    (bookmarked: boolean) => {
+      queryClient.setQueryData<Post>(queryKey, (prev) =>
+        prev ? { ...prev, currentUserBookmarked: bookmarked } : prev,
+      );
+    },
+    [queryClient, queryKey],
+  );
 
   const mutation = useMutation({
-    mutationFn: (bookmarked: boolean) =>
-      bookmarked ? addBookmark(postId) : removeBookmark(postId),
-    onError: () => {
-      if (rollbackRef.current) {
-        queryClient.setQueryData(queryKey, rollbackRef.current);
-      }
-      toast.error("북마크 처리에 실패했습니다.");
+    mutationFn: async (bookmarked: boolean) => {
+      if (bookmarked) await addBookmark(postId);
+      else await removeBookmark(postId);
+      return bookmarked;
     },
-    onSettled: () => {
-      rollbackRef.current = undefined;
-      // 스냅샷 복구는 즉각적인 되돌림일 뿐이고, 진짜 정답은 서버에서 다시 받는다.
-      queryClient.invalidateQueries({ queryKey });
+    onSuccess: (bookmarked) => {
+      serverStateRef.current = bookmarked;
+      if (!hasPendingRef.current) writeBookmarked(bookmarked);
+      // 목록은 서버에서 다시 받아야 한다 (글이 추가/제거됐으므로).
       queryClient.invalidateQueries({ queryKey: bookmarkKeys.all });
+    },
+    onError: () => {
+      if (!hasPendingRef.current && serverStateRef.current !== null) {
+        writeBookmarked(serverStateRef.current);
+      }
+      options?.onError?.();
     },
   });
 
-  const sendDebounced = useDebouncedCallback(
-    (bookmarked: boolean) => mutation.mutate(bookmarked),
-    TOGGLE_DEBOUNCE_MS,
-  );
+  const sendDebounced = useDebouncedCallback((bookmarked: boolean) => {
+    hasPendingRef.current = false;
+    // 짝수 번 연타 등으로 최종 의도가 서버 상태와 같으면 보낼 것이 없다.
+    if (serverStateRef.current === bookmarked) return;
+    mutation.mutate(bookmarked);
+  }, TOGGLE_DEBOUNCE_MS);
 
   const toggle = useCallback(async () => {
-    // 진행 중인 refetch 가 낙관적 값을 덮어쓰지 않도록 먼저 취소한다.
-    // 취소 후에 캐시를 다시 읽어야 그 사이 도착한 응답을 밟지 않는다.
+    // 진행 중인 refetch 가 낙관적 값을 덮어쓰지 않도록 먼저 취소하고,
+    // 취소가 끝난 뒤에 캐시를 읽어야 그 사이 도착한 응답을 밟지 않는다.
     await queryClient.cancelQueries({ queryKey });
 
     const current = queryClient.getQueryData<Post>(queryKey);
     if (!current) return;
 
-    const next = !current.currentUserBookmarked;
-    if (rollbackRef.current === undefined) {
-      rollbackRef.current = current;
+    // 첫 토글 시점의 화면 값이 곧 서버 값이다 (서버에서 받아온 것이므로).
+    if (serverStateRef.current === null) {
+      serverStateRef.current = current.currentUserBookmarked;
     }
-    queryClient.setQueryData<Post>(queryKey, {
-      ...current,
-      currentUserBookmarked: next,
-    });
 
-    // 연타해도 서버로는 마지막 상태 한 번만 나간다.
+    const next = !current.currentUserBookmarked;
+    writeBookmarked(next);
+    hasPendingRef.current = true;
     sendDebounced(next);
-  }, [queryClient, queryKey, sendDebounced]);
+  }, [queryClient, queryKey, sendDebounced, writeBookmarked]);
 
-  return { toggle, isPending: mutation.isPending };
+  return { toggle };
+}
+
+/**
+ * 북마크 해제 전용. 북마크 목록에서 바로 빼기 위한 것으로, 목록의 모든 항목은
+ * 정의상 북마크된 상태라 토글이 필요 없다.
+ */
+export function useRemoveBookmark() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: number) => removeBookmark(postId),
+    onSuccess: (_data, postId) => {
+      queryClient.invalidateQueries({ queryKey: bookmarkKeys.all });
+      queryClient.invalidateQueries({ queryKey: postDetailKey(postId) });
+    },
+  });
 }

--- a/src/entities/community/model/useBookmarkMutation.ts
+++ b/src/entities/community/model/useBookmarkMutation.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useRef } from "react";
+import { useDebouncedCallback } from "@/shared/lib/useDebouncedCallback";
+import { toast } from "@/shared/ui/toast";
+import { addBookmark, removeBookmark } from "../api/bookmarkApi";
+import type { Post } from "../types";
+import { bookmarkKeys, postDetailKey } from "./bookmarkKeys";
+
+const TOGGLE_DEBOUNCE_MS = 400;
+
+/**
+ * 북마크 토글.
+ *
+ * 이 리포에서 낙관적 업데이트를 쓰는 첫 훅이다. 다른 뮤테이션은 전부
+ * `onSuccess → invalidateQueries` 한 가지인데 북마크만 다르게 가는 이유:
+ * 토글은 누른 즉시 반응해야 하고, 왕복을 기다리면 연타 시 버튼이 제멋대로 깜빡인다.
+ *
+ * 낙관적 갱신을 `onMutate` 가 아니라 클릭 시점에 하는 이유도 같다.
+ * 디바운스 때문에 `onMutate` 는 400ms 뒤에나 실행되어 화면이 그만큼 밀린다.
+ */
+export function useBookmarkToggle(postId: number) {
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(() => postDetailKey(postId), [postId]);
+
+  // 연타 한 묶음에서 "첫 클릭 직전" 상태만 보관한다. 매 클릭마다 덮어쓰면
+  // 롤백 대상이 이미 낙관적으로 바뀐 값이 되어 원래대로 못 돌아간다.
+  const rollbackRef = useRef<Post | undefined>(undefined);
+
+  const mutation = useMutation({
+    mutationFn: (bookmarked: boolean) =>
+      bookmarked ? addBookmark(postId) : removeBookmark(postId),
+    onError: () => {
+      if (rollbackRef.current) {
+        queryClient.setQueryData(queryKey, rollbackRef.current);
+      }
+      toast.error("북마크 처리에 실패했습니다.");
+    },
+    onSettled: () => {
+      rollbackRef.current = undefined;
+      // 스냅샷 복구는 즉각적인 되돌림일 뿐이고, 진짜 정답은 서버에서 다시 받는다.
+      queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: bookmarkKeys.all });
+    },
+  });
+
+  const sendDebounced = useDebouncedCallback(
+    (bookmarked: boolean) => mutation.mutate(bookmarked),
+    TOGGLE_DEBOUNCE_MS,
+  );
+
+  const toggle = useCallback(async () => {
+    // 진행 중인 refetch 가 낙관적 값을 덮어쓰지 않도록 먼저 취소한다.
+    // 취소 후에 캐시를 다시 읽어야 그 사이 도착한 응답을 밟지 않는다.
+    await queryClient.cancelQueries({ queryKey });
+
+    const current = queryClient.getQueryData<Post>(queryKey);
+    if (!current) return;
+
+    const next = !current.currentUserBookmarked;
+    if (rollbackRef.current === undefined) {
+      rollbackRef.current = current;
+    }
+    queryClient.setQueryData<Post>(queryKey, {
+      ...current,
+      currentUserBookmarked: next,
+    });
+
+    // 연타해도 서버로는 마지막 상태 한 번만 나간다.
+    sendDebounced(next);
+  }, [queryClient, queryKey, sendDebounced]);
+
+  return { toggle, isPending: mutation.isPending };
+}

--- a/src/entities/community/model/useMyBookmarks.ts
+++ b/src/entities/community/model/useMyBookmarks.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMyBookmarks } from "../api/bookmarkApi";
+import { bookmarkKeys } from "./bookmarkKeys";
+
+/**
+ * 마이페이지 "북마크한 글" 목록.
+ * 공개 목록(usePosts)과 달리 무한스크롤이 아니라 페이지 단위다 — useMyDuoPosts 와 같은 형태.
+ */
+export function useMyBookmarks(page: number = 0) {
+  return useQuery({
+    queryKey: bookmarkKeys.myList(page),
+    queryFn: () => getMyBookmarks(page),
+    staleTime: 1 * 60 * 1000,
+  });
+}

--- a/src/entities/community/types.ts
+++ b/src/entities/community/types.ts
@@ -55,6 +55,7 @@ export interface Post {
   commentCount: number;
   author: Author;
   currentUserVote: VoteType | null;
+  currentUserBookmarked: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/entities/community/ui/PostCard.tsx
+++ b/src/entities/community/ui/PostCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type { PostListItem } from "@/entities/community";
-import { POST_CATEGORY_LABELS } from "@/entities/community";
+import type { PostListItem } from "../types";
+import { POST_CATEGORY_LABELS } from "../types";
 import { Eye, MessageSquare, ThumbsUp } from "lucide-react";
 import Link from "next/link";
 import { getRelativeTime } from "@/shared/lib/date";

--- a/src/features/community-bookmark/index.ts
+++ b/src/features/community-bookmark/index.ts
@@ -1,0 +1,1 @@
+export { default as BookmarkButton } from "./ui/BookmarkButton";

--- a/src/features/community-bookmark/ui/BookmarkButton.tsx
+++ b/src/features/community-bookmark/ui/BookmarkButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Bookmark } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useAuthStore } from "@/entities/auth";
+import { useBookmarkToggle } from "@/entities/community";
+
+interface BookmarkButtonProps {
+  postId: number;
+  bookmarked: boolean;
+}
+
+export default function BookmarkButton({
+  postId,
+  bookmarked,
+}: BookmarkButtonProps) {
+  const router = useRouter();
+  const user = useAuthStore((s) => s.user);
+  const { toggle } = useBookmarkToggle(postId);
+
+  const handleClick = () => {
+    if (!user) {
+      router.push("/login");
+      return;
+    }
+    void toggle();
+  };
+
+  // 요청 중이라고 버튼을 잠그지 않는다. 디바운스로 요청은 한 번만 나가므로
+  // 잠글 이유가 없고, 잠그면 되돌리려는 클릭까지 막혀 오히려 답답해진다.
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-pressed={bookmarked}
+      className={`flex items-center gap-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors cursor-pointer ${
+        bookmarked
+          ? "bg-primary/20 text-primary border border-primary/50"
+          : "bg-surface-4 hover:bg-surface-8 border border-divider text-on-surface-medium"
+      }`}
+    >
+      <Bookmark className={`w-4 h-4 ${bookmarked ? "fill-current" : ""}`} />
+      {bookmarked ? "저장됨" : "저장"}
+    </button>
+  );
+}

--- a/src/features/community-bookmark/ui/BookmarkButton.tsx
+++ b/src/features/community-bookmark/ui/BookmarkButton.tsx
@@ -4,6 +4,7 @@ import { Bookmark } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/entities/auth";
 import { useBookmarkToggle } from "@/entities/community";
+import { toast } from "@/shared/ui/toast";
 
 interface BookmarkButtonProps {
   postId: number;
@@ -16,7 +17,11 @@ export default function BookmarkButton({
 }: BookmarkButtonProps) {
   const router = useRouter();
   const user = useAuthStore((s) => s.user);
-  const { toggle } = useBookmarkToggle(postId);
+  // 토스트는 호출부가 붙인다 — entities 훅은 UI 를 모른다
+  // (useVoteMutation 등 기존 뮤테이션과 같은 컨벤션).
+  const { toggle } = useBookmarkToggle(postId, {
+    onError: () => toast.error("북마크 처리에 실패했습니다."),
+  });
 
   const handleClick = () => {
     if (!user) {

--- a/src/shared/lib/useDebouncedCallback.ts
+++ b/src/shared/lib/useDebouncedCallback.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * 마지막 호출만 delay 후에 실행한다.
+ *
+ * 낙관적 업데이트와 짝을 이루는 토글(북마크 등)에서 필요하다. 디바운스가 없으면
+ * 연타 시 POST 와 DELETE 가 뒤바뀐 순서로 서버에 도착할 수 있고, 그러면
+ * 서버는 "북마크됨" 인데 화면은 "해제됨" 인 상태가 되어 새로고침 전까지 아무도 모른다.
+ * 서버를 멱등하게 만들어도 도착 순서 문제는 풀리지 않으므로, 요청 자체를 하나로 줄인다.
+ *
+ * 대기 중인 호출이 있는 상태로 언마운트되면 그 호출을 즉시 실행한다(flush).
+ * 사용자가 마지막으로 누른 상태가 서버에 반영되지 않은 채 페이지를 떠나면 안 된다.
+ */
+export function useDebouncedCallback<A extends unknown[]>(
+  callback: (...args: A) => void,
+  delayMs: number,
+) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingArgsRef = useRef<A | null>(null);
+  const callbackRef = useRef(callback);
+
+  // 렌더 중 ref 에 쓰지 않는다 — 최신 콜백은 커밋 후에 반영한다.
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current === null) return;
+      clearTimeout(timerRef.current);
+      const args = pendingArgsRef.current;
+      pendingArgsRef.current = null;
+      if (args) callbackRef.current(...args);
+    };
+  }, []);
+
+  return useCallback(
+    (...args: A) => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      pendingArgsRef.current = args;
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        const pending = pendingArgsRef.current;
+        pendingArgsRef.current = null;
+        if (pending) callbackRef.current(...pending);
+      }, delayMs);
+    },
+    [delayMs],
+  );
+}

--- a/src/widgets/community-detail/ui/PostDetailPanel.tsx
+++ b/src/widgets/community-detail/ui/PostDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
 import type { VoteType } from "@/entities/community";
 import { useAuthStore } from "@/entities/auth";
 import { VoteButtons } from "@/shared/ui/vote-buttons";
+import { BookmarkButton } from "@/features/community-bookmark";
 import { ConfirmModal } from "@/shared/ui/modal";
 import { toast } from "@/shared/ui/toast";
 import { formatDate } from "@/shared/lib/date";
@@ -140,13 +141,17 @@ export default function PostDetailPanel({ postId }: PostDetailPanelProps) {
           {post.content}
         </div>
 
-        <div className="flex justify-center">
+        <div className="flex items-center justify-between gap-4">
           <VoteButtons
             upvoteCount={post.upvoteCount}
             downvoteCount={post.downvoteCount}
             currentUserVote={post.currentUserVote}
             onVote={handleVote}
             isPending={isVotePending}
+          />
+          <BookmarkButton
+            postId={post.id}
+            bookmarked={post.currentUserBookmarked}
           />
         </div>
       </div>

--- a/src/widgets/community-list/index.ts
+++ b/src/widgets/community-list/index.ts
@@ -1,1 +1,2 @@
 export { default as CommunityListPanel } from "./ui/CommunityListPanel";
+export { default as PostCard } from "./ui/PostCard";

--- a/src/widgets/community-list/index.ts
+++ b/src/widgets/community-list/index.ts
@@ -1,2 +1,1 @@
 export { default as CommunityListPanel } from "./ui/CommunityListPanel";
-export { default as PostCard } from "./ui/PostCard";

--- a/src/widgets/community-list/ui/CommunityListPanel.tsx
+++ b/src/widgets/community-list/ui/CommunityListPanel.tsx
@@ -14,7 +14,7 @@ import {
 import type { PostCategory, PostSort, PostPeriod } from "@/entities/community";
 import { useAuthStore } from "@/entities/auth";
 import { CommunitySearchBar } from "@/features/community-search";
-import PostCard from "./PostCard";
+import { PostCard } from "@/entities/community";
 
 const CATEGORIES: (PostCategory | "ALL")[] = ["ALL", ...POST_CATEGORIES];
 const SORTS: PostSort[] = ["HOT", "NEW", "TOP"];

--- a/src/widgets/mypage-panel/ui/BookmarksSection.tsx
+++ b/src/widgets/mypage-panel/ui/BookmarksSection.tsx
@@ -1,13 +1,21 @@
 "use client";
 
 import { useState } from "react";
-import { useMyBookmarks } from "@/entities/community";
-import { PostCard } from "@/widgets/community-list";
+import { BookmarkX } from "lucide-react";
+import { PostCard, useMyBookmarks, useRemoveBookmark } from "@/entities/community";
+import { toast } from "@/shared/ui/toast";
 
 export default function BookmarksSection() {
   const [page, setPage] = useState(0);
-  const { data, isLoading, isFetching } = useMyBookmarks(page);
+  const { data, isLoading, isError, isFetching, refetch } = useMyBookmarks(page);
+  const removeMutation = useRemoveBookmark();
   const posts = data?.content ?? [];
+
+  const handleRemove = (postId: number) => {
+    removeMutation.mutate(postId, {
+      onError: () => toast.error("북마크 해제에 실패했습니다."),
+    });
+  };
 
   return (
     <section>
@@ -22,21 +30,50 @@ export default function BookmarksSection() {
             />
           ))}
         </div>
+      ) : isError ? (
+        /* 실패를 빈 목록으로 보여주면 북마크가 전부 날아간 것처럼 읽힌다. */
+        <div className="text-center py-16">
+          <p className="text-on-surface-medium mb-4">
+            북마크를 불러오지 못했습니다.
+          </p>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            disabled={isFetching}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-surface-4 border border-divider text-on-surface hover:bg-surface-8 transition-colors disabled:opacity-50 cursor-pointer"
+          >
+            {isFetching ? "불러오는 중..." : "다시 시도"}
+          </button>
+        </div>
       ) : posts.length === 0 ? (
         <div className="text-center py-16 text-on-surface-disabled">
-          {page === 0
-            ? "북마크한 글이 없습니다"
-            : "이 페이지에는 글이 없습니다"}
+          {page === 0 ? "북마크한 글이 없습니다" : "이 페이지에는 글이 없습니다"}
         </div>
       ) : (
         <div className="space-y-2">
           {posts.map((post) => (
-            <PostCard key={post.id} post={post} />
+            /* 해제 버튼은 PostCard(<Link>) 안이 아니라 형제로 둔다.
+               링크 안에 버튼을 중첩하면 클릭이 서로 먹고 stopPropagation 에 의존하게 된다. */
+            <div key={post.id} className="flex items-start gap-2">
+              <div className="flex-1 min-w-0">
+                <PostCard post={post} />
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRemove(post.id)}
+                disabled={removeMutation.isPending}
+                aria-label="북마크 해제"
+                title="북마크 해제"
+                className="shrink-0 p-2 mt-1 rounded-md text-on-surface-disabled hover:text-error hover:bg-surface-4 transition-colors disabled:opacity-50 cursor-pointer"
+              >
+                <BookmarkX className="w-4 h-4" />
+              </button>
+            </div>
           ))}
         </div>
       )}
 
-      {(page > 0 || data?.hasNext) && (
+      {!isError && (page > 0 || data?.hasNext) && (
         <div className="flex items-center justify-center gap-2 mt-6">
           <button
             type="button"
@@ -46,9 +83,7 @@ export default function BookmarksSection() {
           >
             이전
           </button>
-          <span className="text-sm text-on-surface-disabled px-2">
-            {page + 1}
-          </span>
+          <span className="text-sm text-on-surface-disabled px-2">{page + 1}</span>
           <button
             type="button"
             onClick={() => setPage((p) => p + 1)}

--- a/src/widgets/mypage-panel/ui/BookmarksSection.tsx
+++ b/src/widgets/mypage-panel/ui/BookmarksSection.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { useMyBookmarks } from "@/entities/community";
+import { PostCard } from "@/widgets/community-list";
+
+export default function BookmarksSection() {
+  const [page, setPage] = useState(0);
+  const { data, isLoading, isFetching } = useMyBookmarks(page);
+  const posts = data?.content ?? [];
+
+  return (
+    <section>
+      <h2 className="text-lg font-bold text-on-surface mb-6">북마크한 글</h2>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="bg-surface-1 border border-divider rounded-lg p-4 animate-pulse h-[92px]"
+            />
+          ))}
+        </div>
+      ) : posts.length === 0 ? (
+        <div className="text-center py-16 text-on-surface-disabled">
+          {page === 0
+            ? "북마크한 글이 없습니다"
+            : "이 페이지에는 글이 없습니다"}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} />
+          ))}
+        </div>
+      )}
+
+      {(page > 0 || data?.hasNext) && (
+        <div className="flex items-center justify-center gap-2 mt-6">
+          <button
+            type="button"
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0 || isFetching}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-surface-4 border border-divider text-on-surface-medium hover:bg-surface-8 transition-colors disabled:opacity-50 cursor-pointer"
+          >
+            이전
+          </button>
+          <span className="text-sm text-on-surface-disabled px-2">
+            {page + 1}
+          </span>
+          <button
+            type="button"
+            onClick={() => setPage((p) => p + 1)}
+            disabled={!data?.hasNext || isFetching}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-surface-4 border border-divider text-on-surface-medium hover:bg-surface-8 transition-colors disabled:opacity-50 cursor-pointer"
+          >
+            다음
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/widgets/mypage-panel/ui/MypagePanel.tsx
+++ b/src/widgets/mypage-panel/ui/MypagePanel.tsx
@@ -4,7 +4,8 @@ import { Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import MypageSidebar from "./MypageSidebar";
 import AccountSection from "./AccountSection";
-export type Tab = "account";
+import BookmarksSection from "./BookmarksSection";
+export type Tab = "account" | "bookmarks";
 
 function MypagePanelContent() {
   const searchParams = useSearchParams();
@@ -20,6 +21,7 @@ function MypagePanelContent() {
       <MypageSidebar activeTab={tab} onTabChange={handleTabChange} />
       <div className="flex-1 min-w-0">
         {tab === "account" && <AccountSection />}
+        {tab === "bookmarks" && <BookmarksSection />}
       </div>
     </div>
   );

--- a/src/widgets/mypage-panel/ui/MypageSidebar.tsx
+++ b/src/widgets/mypage-panel/ui/MypageSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LogOut, User } from "lucide-react";
+import { Bookmark, LogOut, User } from "lucide-react";
 import { useLogout } from "@/features/auth";
 import type { Tab } from "./MypagePanel";
 
@@ -11,6 +11,7 @@ interface MypageSidebarProps {
 
 const tabs: { key: Tab; label: string; icon: typeof User }[] = [
   { key: "account", label: "계정 관리", icon: User },
+  { key: "bookmarks", label: "북마크한 글", icon: Bookmark },
 ];
 
 export default function MypageSidebar({


### PR DESCRIPTION
커뮤니티 북마크 UI 입니다. 커밋 2개.

## 🔴 스택 PR — base 가 develop 이 아닙니다

STEP 0(공용 Toast/Modal, #186)을 쓰기 때문에 그 브랜치 위에 쌓았습니다.
**#186 이 먼저 머지되면 base 를 `develop` 으로 바꿔주세요.**

릴리스 순서로는 4단계(마지막)입니다: `lol-db-schema V31` → `lol-repository` → `lol-server`(#140) → **이 PR**.
서버 API 가 배포되기 전에는 동작하지 않습니다. (`deploy.yml` 은 `main` 에서만 도므로 develop 머지 자체는 안전합니다.)

## 변경

- 게시글 상세: 좌 투표 / 우 북마크 (`justify-center` → `justify-between`)
- 마이페이지 `?tab=bookmarks` — "북마크한 글" 목록 + 항목별 해제
- `useDebouncedCallback` (신규, `shared/lib`)

## 낙관적 업데이트 — 이 리포 최초입니다

기존 뮤테이션은 **전부** `onSuccess → invalidateQueries` 한 가지입니다. `onMutate`/`cancelQueries`/`setQueryData` 는 코드베이스에 한 건도 없었습니다. 북마크만 다르게 가는 이유는 토글이라서입니다 — 누른 즉시 반응해야 하고, 왕복을 기다리면 연타 시 버튼이 깜빡입니다.

**낙관적 갱신을 `onMutate` 가 아니라 클릭 시점에 합니다.** 디바운스 때문에 `onMutate` 는 400ms 뒤에나 실행되어, 거기 두면 버튼이 그만큼 밀립니다. 디바운스와 낙관적 업데이트를 같이 쓸 때만 생기는 함정입니다.

**디바운스가 필요한 이유는 UX 가 아니라 데이터 정합성입니다.** 없으면 연타 시 POST 와 DELETE 가 뒤바뀐 순서로 도착해 **서버는 "북마크됨", 화면은 "해제됨"** 인 상태가 되고 새로고침 전까지 아무도 모릅니다. 서버를 멱등하게 만들어도 도착 순서는 풀리지 않습니다.

## 적대적 리뷰에서 뒤집은 것

1차 구현은 `rollbackRef` + `invalidateQueries` + 디바운스를 다 넣었는데, **세 장치가 서로의 전제를 깨고 있었습니다.**

- **더블클릭하면 반드시 에러 토스트가 떴습니다.** 짝수 번 연타하면 최종 의도가 원래 상태와 같은데 그대로 요청을 보내 409/404 를 받았습니다. → 서버 상태와 같은 요청은 보내지 않고, 409(이미 북마크됨)/404(북마크 없음)는 **"실패"가 아니라 "이미 원하는 상태"** 이므로 API 계층에서 접어 멱등하게 만들었습니다.
- **`onSettled` 의 invalidate 가 대기 중인 낙관적 값을 덮어써서, 이 훅이 막겠다던 깜빡임을 스스로 만들고 있었습니다.** → 상세 캐시는 invalidate 하지 않고 확정값을 직접 씁니다. 아직 발사 안 된 클릭이 있으면 서버 응답으로 화면을 건드리지 않습니다.
- **`Post` 통짜 스냅샷을 되돌리며 그 사이 바뀐 추천 수까지 되감았습니다.** → 되돌릴 대상은 boolean 하나입니다.
- 토스트를 entities 훅에서 호출부로 옮겼습니다(기존 컨벤션 정렬).
- **목록 조회 실패가 "북마크한 글이 없습니다"로 표시**되고 재시도 수단도 없었습니다 → 에러 상태 + 다시 시도 버튼.
- **목록에서 북마크를 해제할 방법이 없었습니다**(상세로 들어가야만 가능) → 해제 버튼 추가. `PostCard` 가 `<Link>` 라서 **버튼을 안에 중첩하지 않고 형제로** 뒀습니다.
- `PostCard` 를 `widgets/community-list` → `entities/community/ui` 로 이동. widget→widget 임포트였고, 배럴을 타고 `CommunityListPanel` 청크까지 마이페이지로 끌려오고 있었습니다.

## 검증

- [x] `npx tsc --noEmit`
- [x] `pnpm lint` — **0 errors** (warning 5건은 이 PR 이 건드리지 않은 기존 파일)
- [x] `pnpm build` — 18개 페이지 생성

**미검증 — 서버 배포 전이라 런타임 확인을 못 했습니다.** 머지 전 확인 권장:
- [ ] 🔴 **연타 검증** — 빠르게 5회 클릭 → 3초 대기 → 새로고침, 화면과 서버 상태 일치
- [ ] 더블클릭 시 에러 토스트가 **뜨지 않는지**
- [ ] 응답 지연 중 재클릭 시 버튼이 되돌아갔다 오지 않는지
- [ ] 비로그인 클릭 → 로그인 페이지 이동
- [ ] 마이페이지 목록/해제, 오프라인 시 에러+재시도

## 남겨둔 것

- **페이지 번호가 URL 에 없습니다.** 3페이지에서 글을 열고 뒤로가기 하면 1페이지로 돌아옵니다. 탭은 `?tab=` 인데 페이지만 로컬 state 입니다.
- **로그인 리다이렉트에 returnUrl 이 없습니다.** 기존 `handleVote` 도 동일한 기존 부채이나, 이번에 진입점이 하나 늘었습니다.
- **언마운트 flush 로 나간 요청이 실패하면 다른 페이지에서 토스트가 뜹니다.** 마지막 의도를 서버에 반영하는 편이 낫다고 보아 flush 는 유지했습니다. 이제 서버 상태와 같으면 발사 자체를 안 하므로 빈도는 크게 줄었습니다.
- **MP 번호 없음** — 발급받지 못했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCTseN4Lk5uXhMTkJZjWVM