### PR TITLE
feat: 네비게이션 커뮤니티 메뉴 활성화

### DIFF
--- a/src/widgets/layout/ui/Navigation.tsx
+++ b/src/widgets/layout/ui/Navigation.tsx
@@ -16,7 +16,7 @@ export default function Navigation() {
     { label: "챔피언 분석", href: "/champion-stats" },
     { label: "랭킹", href: "/leaderboards" },
     { label: "패치노트", href: "/patch-notes" },
-    // { label: "커뮤니티", href: "/community" },
+    { label: "커뮤니티", href: "/community" },
     { label: "듀오 찾기", href: "/duo" },
   ];
 


### PR DESCRIPTION
## 요약

상단 네비게이션에서 주석 처리되어 있던 **커뮤니티** 메뉴 항목을 활성화했습니다.

## 배경

커뮤니티 관련 기능은 이미 구현이 완료된 상태입니다.

- 페이지: `/community`, `/community/[postId]`, `/community/write`, `/community/[postId]/edit`
- 위젯: `community-list`, `community-detail`
- 기능: `community-search`, `community-comment`, `community-post-editor`, `community-bookmark`
- 엔티티: `entities/community`

하지만 `src/widgets/layout/ui/Navigation.tsx` 의 `navItems` 에서 커뮤니티 항목만 주석 처리되어 있어 사용자가 UI 상으로 진입할 수 없었습니다.

## 변경 사항

`src/widgets/layout/ui/Navigation.tsx` — 커뮤니티 nav 항목 주석 해제 (1줄)

```diff
-    // { label: "커뮤니티", href: "/community" },
+    { label: "커뮤니티", href: "/community" },
```

## 검증

- `pnpm lint` — 에러 0 (경고 5건은 기존 duo 관련 코드로 본 변경과 무관)
- `pnpm build` — 성공. `/community`, `/community/[postId]`, `/community/[postId]/edit`, `/community/write` 라우트 정상 생성 확인

🤖 Generated by Padosol