### PR TITLE
feat: MP-XXX 네비게이션 챔피언 분석·패치노트 메뉴 비활성화

### DIFF
--- a/src/widgets/layout/ui/Navigation.tsx
+++ b/src/widgets/layout/ui/Navigation.tsx
@@ -13,9 +13,9 @@ export default function Navigation() {
 
   const navItems = [
     { label: "홈", href: "/" },
-    { label: "챔피언 분석", href: "/champion-stats" },
+    // { label: "챔피언 분석", href: "/champion-stats" },
     { label: "랭킹", href: "/leaderboards" },
-    { label: "패치노트", href: "/patch-notes" },
+    // { label: "패치노트", href: "/patch-notes" },
     { label: "커뮤니티", href: "/community" },
     { label: "듀오 찾기", href: "/duo" },
   ];


### PR DESCRIPTION
## 요약

상단 네비게이션에서 **챔피언 분석**, **패치노트** 진입점을 내리고 **커뮤니티**는 계속 노출합니다.

## 변경 내용

- `src/widgets/layout/ui/Navigation.tsx` 의 `navItems` 에서 `챔피언 분석`, `패치노트` 항목을 주석 처리
- 커뮤니티 항목은 기존대로 활성 유지 (#188 에서 이미 노출됨)

메뉴 항목만 주석 처리했고 `/champion-stats`, `/patch-notes` 라우트·페이지·사이트맵은 그대로 두었습니다. 직접 URL 접근과 홈 화면 패치노트 섹션은 계속 동작하며, 다시 열 때 주석만 해제하면 됩니다 (#188 의 커뮤니티 활성화와 동일한 방식).

## 확인

- `pnpm lint` — error 0 (기존 duo 관련 warning 5건만 잔존)
- `pnpm build` — 성공, 라우트 목록 변화 없음

🤖 Generated by Padosol