### PR TITLE
release: develop → main (듀오 API 연동 · 커뮤니티 북마크 · 공통 Toast/Modal)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "19.2.4",
     "react-error-boundary": "^6.1.1",
     "react-hook-form": "^7.71.2",
+    "sonner": "^2.0.7",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-hook-form:
         specifier: ^7.71.2
         version: 7.71.2(react@19.2.4)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1996,6 +1999,12 @@ packages:
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4277,6 +4286,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { QueryProvider } from "@/shared/providers/QueryProvider";
 import GameDataLoader from "./GameDataLoader";
 import { ThemeProvider } from "@/shared/providers/ThemeProvider";
+import { Toaster } from "@/shared/ui/toast";
 import type { Metadata } from "next";
 import { Geist } from "next/font/google";
 import "./globals.css";
@@ -38,6 +39,7 @@ export default function RootLayout({
           <ThemeProvider>
             <GameDataLoader />
             {children}
+            <Toaster />
           </ThemeProvider>
         </QueryProvider>
       </body>

--- a/src/entities/champion/index.ts
+++ b/src/entities/champion/index.ts
@@ -4,6 +4,7 @@ export { getChampionPositionStats } from "./api/championPositionStatsApi";
 export { useChampionRotate } from "./model/useChampionRotate";
 export { useChampionStats } from "./model/useChampionStats";
 export { useChampionPositionStats } from "./model/useChampionPositionStats";
+export { useChampionById, useChampionsByIds } from "./model/useChampion";
 export { getChampionById, getChampionsByIds, getChampionImageUrl, getChampionNameByEnglishName } from "./lib/championImage";
 export { WIN_RATE_COLOR_CLASSES, getWinRateTextClass, calcWinRateCeil2 } from "./lib/championStatsUtils";
 export { getTierBadgeClass } from "./lib/tierBadge";

--- a/src/entities/champion/model/useChampion.ts
+++ b/src/entities/champion/model/useChampion.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+import {
+  useGameDataStore,
+  type ChampionData,
+} from "@/shared/model/game-data";
+
+export function useChampionById(championId: number): ChampionData | null {
+  const championData = useGameDataStore((s) => s.championData);
+
+  return useMemo(() => {
+    if (!championData) {
+      return null;
+    }
+    const champion = Object.values(championData.data).find(
+      (c) => c.key === String(championId)
+    );
+    return champion || null;
+  }, [championData, championId]);
+}
+
+export function useChampionsByIds(championIds: number[]): ChampionData[] {
+  const championData = useGameDataStore((s) => s.championData);
+  const idsKey = championIds.join(",");
+
+  return useMemo(() => {
+    if (!championData) {
+      return [];
+    }
+    const idSet = new Set(idsKey ? idsKey.split(",") : []);
+    return Object.values(championData.data).filter((c) => idSet.has(c.key));
+  }, [championData, idsKey]);
+}

--- a/src/entities/community/api/bookmarkApi.ts
+++ b/src/entities/community/api/bookmarkApi.ts
@@ -1,0 +1,21 @@
+import { apiClient } from "@/shared/api/client";
+import type { ApiResponse } from "@/shared/api/types";
+import type { PostListResponse } from "../types";
+
+export async function addBookmark(postId: number): Promise<void> {
+  await apiClient.post("/community/bookmarks", { postId });
+}
+
+export async function removeBookmark(postId: number): Promise<void> {
+  await apiClient.delete(`/community/bookmarks/${postId}`);
+}
+
+export async function getMyBookmarks(
+  page: number = 0
+): Promise<PostListResponse> {
+  const response = await apiClient.get<ApiResponse<PostListResponse>>(
+    "/community/me/bookmarks",
+    { params: { page } }
+  );
+  return response.data.data;
+}

--- a/src/entities/community/api/bookmarkApi.ts
+++ b/src/entities/community/api/bookmarkApi.ts
@@ -2,12 +2,35 @@ import { apiClient } from "@/shared/api/client";
 import type { ApiResponse } from "@/shared/api/types";
 import type { PostListResponse } from "../types";
 
+function statusOf(error: unknown): number | undefined {
+  if (typeof error === "object" && error !== null && "response" in error) {
+    return (error as { response?: { status?: number } }).response?.status;
+  }
+  return undefined;
+}
+
+/**
+ * 이 파일은 entities API 중 유일하게 예외를 흡수한다.
+ *
+ * 서버는 중복 북마크에 409, 없는 북마크 해제에 404 를 준다. 둘 다 "요청이 실패했다"가
+ * 아니라 "원하는 상태에 이미 도달해 있다"는 뜻이다. 토글에서는 성공과 구분할 이유가
+ * 없고, 구분하면 더블클릭처럼 흔한 조작이 곧바로 에러로 보인다.
+ * 여기서 접어서 add/remove 를 멱등하게 만든다.
+ */
 export async function addBookmark(postId: number): Promise<void> {
-  await apiClient.post("/community/bookmarks", { postId });
+  try {
+    await apiClient.post("/community/bookmarks", { postId });
+  } catch (error) {
+    if (statusOf(error) !== 409) throw error;
+  }
 }
 
 export async function removeBookmark(postId: number): Promise<void> {
-  await apiClient.delete(`/community/bookmarks/${postId}`);
+  try {
+    await apiClient.delete(`/community/bookmarks/${postId}`);
+  } catch (error) {
+    if (statusOf(error) !== 404) throw error;
+  }
 }
 
 export async function getMyBookmarks(

--- a/src/entities/community/index.ts
+++ b/src/entities/community/index.ts
@@ -39,4 +39,6 @@ export { useCreateComment, useUpdateComment, useDeleteComment } from "./model/us
 export { useVote, useRemoveVote } from "./model/useVoteMutation";
 export { useBookmarkToggle } from "./model/useBookmarkMutation";
 export { useMyBookmarks } from "./model/useMyBookmarks";
-export { bookmarkKeys } from "./model/bookmarkKeys";
+export { bookmarkKeys, postDetailKey } from "./model/bookmarkKeys";
+export { useRemoveBookmark } from "./model/useBookmarkMutation";
+export { default as PostCard } from "./ui/PostCard";

--- a/src/entities/community/index.ts
+++ b/src/entities/community/index.ts
@@ -29,6 +29,7 @@ export {
 export { getPosts, getPostDetail, createPost, updatePost, deletePost, searchPosts, getMyPosts } from "./api/communityApi";
 export { getComments, createComment, updateComment, deleteComment } from "./api/commentApi";
 export { vote, removeVote } from "./api/voteApi";
+export { addBookmark, removeBookmark, getMyBookmarks } from "./api/bookmarkApi";
 
 export { usePosts, useSearchPosts, useMyPosts } from "./model/usePosts";
 export { usePostDetail } from "./model/usePostDetail";
@@ -36,3 +37,6 @@ export { useComments } from "./model/useComments";
 export { useCreatePost, useUpdatePost, useDeletePost } from "./model/usePostMutations";
 export { useCreateComment, useUpdateComment, useDeleteComment } from "./model/useCommentMutations";
 export { useVote, useRemoveVote } from "./model/useVoteMutation";
+export { useBookmarkToggle } from "./model/useBookmarkMutation";
+export { useMyBookmarks } from "./model/useMyBookmarks";
+export { bookmarkKeys } from "./model/bookmarkKeys";

--- a/src/entities/community/model/bookmarkKeys.ts
+++ b/src/entities/community/model/bookmarkKeys.ts
@@ -1,0 +1,14 @@
+/**
+ * 북마크 쿼리 키. duoKeys 와 같은 factory 형태다.
+ *
+ * 기존 community 쿼리들은 인라인 문자열 배열을 쓰고 있어서, 그쪽 캐시를
+ * invalidate 할 때는 리터럴을 그대로 맞춰 써야 한다 (communityKeys 전면 정리는 별건).
+ */
+export const bookmarkKeys = {
+  all: ["community", "bookmarks"] as const,
+  myList: (page: number) => [...bookmarkKeys.all, "my", page] as const,
+};
+
+/** 게시글 상세 캐시 키 — usePostDetail.ts 의 리터럴과 반드시 같아야 한다. */
+export const postDetailKey = (postId: number) =>
+  ["community", "post", postId] as const;

--- a/src/entities/community/model/useBookmarkMutation.ts
+++ b/src/entities/community/model/useBookmarkMutation.ts
@@ -3,73 +3,118 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef } from "react";
 import { useDebouncedCallback } from "@/shared/lib/useDebouncedCallback";
-import { toast } from "@/shared/ui/toast";
 import { addBookmark, removeBookmark } from "../api/bookmarkApi";
 import type { Post } from "../types";
 import { bookmarkKeys, postDetailKey } from "./bookmarkKeys";
 
 const TOGGLE_DEBOUNCE_MS = 400;
 
+interface UseBookmarkToggleOptions {
+  /** 실패를 사용자에게 알리는 방법은 호출부가 정한다 (entities 는 UI 를 모른다). */
+  onError?: () => void;
+}
+
 /**
  * 북마크 토글.
  *
  * 이 리포에서 낙관적 업데이트를 쓰는 첫 훅이다. 다른 뮤테이션은 전부
- * `onSuccess → invalidateQueries` 한 가지인데 북마크만 다르게 가는 이유:
- * 토글은 누른 즉시 반응해야 하고, 왕복을 기다리면 연타 시 버튼이 제멋대로 깜빡인다.
+ * `onSuccess → invalidateQueries` 한 가지인데 북마크만 다르게 가는 이유는 토글이라서다.
+ * 누른 즉시 반응해야 하고, 왕복을 기다리면 연타 시 버튼이 제멋대로 깜빡인다.
  *
- * 낙관적 갱신을 `onMutate` 가 아니라 클릭 시점에 하는 이유도 같다.
- * 디바운스 때문에 `onMutate` 는 400ms 뒤에나 실행되어 화면이 그만큼 밀린다.
+ * 세 가지를 의도적으로 하지 않는다.
+ *
+ * 1. **상세 캐시를 invalidate 하지 않는다.** 응답이 오는 시점엔 이미 다음 클릭의
+ *    낙관적 값이 화면에 있을 수 있고, refetch 가 그걸 덮으면 버튼이 되돌아갔다 온다
+ *    (= 이 훅이 막으려던 깜빡임을 스스로 만든다). 확정값을 직접 써넣는다.
+ * 2. **Post 전체를 스냅샷하지 않는다.** 통짜로 되돌리면 그 사이 바뀐 추천 수·조회 수까지
+ *    같이 되감긴다. 되돌릴 대상은 boolean 하나다.
+ * 3. **서버 상태와 같은 요청은 보내지 않는다.** 짝수 번 연타하면 최종 의도가 원래
+ *    상태와 같은데, 그걸 그대로 보내면 서버는 409/404 를 준다.
  */
-export function useBookmarkToggle(postId: number) {
+export function useBookmarkToggle(
+  postId: number,
+  options?: UseBookmarkToggleOptions,
+) {
   const queryClient = useQueryClient();
   const queryKey = useMemo(() => postDetailKey(postId), [postId]);
 
-  // 연타 한 묶음에서 "첫 클릭 직전" 상태만 보관한다. 매 클릭마다 덮어쓰면
-  // 롤백 대상이 이미 낙관적으로 바뀐 값이 되어 원래대로 못 돌아간다.
-  const rollbackRef = useRef<Post | undefined>(undefined);
+  // 서버가 확인해준 마지막 상태. 낙관적 값과 반드시 구분해서 들고 있어야
+  // 보낼 필요 없는 요청을 걸러내고, 실패했을 때 되돌릴 곳을 안다.
+  const serverStateRef = useRef<boolean | null>(null);
+  // 아직 발사되지 않은 클릭이 남아 있는지. 남아 있으면 서버 응답으로
+  // 화면을 건드리면 안 된다 — 더 최신 의도가 이미 화면에 있다.
+  const hasPendingRef = useRef(false);
+
+  const writeBookmarked = useCallback(
+    (bookmarked: boolean) => {
+      queryClient.setQueryData<Post>(queryKey, (prev) =>
+        prev ? { ...prev, currentUserBookmarked: bookmarked } : prev,
+      );
+    },
+    [queryClient, queryKey],
+  );
 
   const mutation = useMutation({
-    mutationFn: (bookmarked: boolean) =>
-      bookmarked ? addBookmark(postId) : removeBookmark(postId),
-    onError: () => {
-      if (rollbackRef.current) {
-        queryClient.setQueryData(queryKey, rollbackRef.current);
-      }
-      toast.error("북마크 처리에 실패했습니다.");
+    mutationFn: async (bookmarked: boolean) => {
+      if (bookmarked) await addBookmark(postId);
+      else await removeBookmark(postId);
+      return bookmarked;
     },
-    onSettled: () => {
-      rollbackRef.current = undefined;
-      // 스냅샷 복구는 즉각적인 되돌림일 뿐이고, 진짜 정답은 서버에서 다시 받는다.
-      queryClient.invalidateQueries({ queryKey });
+    onSuccess: (bookmarked) => {
+      serverStateRef.current = bookmarked;
+      if (!hasPendingRef.current) writeBookmarked(bookmarked);
+      // 목록은 서버에서 다시 받아야 한다 (글이 추가/제거됐으므로).
       queryClient.invalidateQueries({ queryKey: bookmarkKeys.all });
+    },
+    onError: () => {
+      if (!hasPendingRef.current && serverStateRef.current !== null) {
+        writeBookmarked(serverStateRef.current);
+      }
+      options?.onError?.();
     },
   });
 
-  const sendDebounced = useDebouncedCallback(
-    (bookmarked: boolean) => mutation.mutate(bookmarked),
-    TOGGLE_DEBOUNCE_MS,
-  );
+  const sendDebounced = useDebouncedCallback((bookmarked: boolean) => {
+    hasPendingRef.current = false;
+    // 짝수 번 연타 등으로 최종 의도가 서버 상태와 같으면 보낼 것이 없다.
+    if (serverStateRef.current === bookmarked) return;
+    mutation.mutate(bookmarked);
+  }, TOGGLE_DEBOUNCE_MS);
 
   const toggle = useCallback(async () => {
-    // 진행 중인 refetch 가 낙관적 값을 덮어쓰지 않도록 먼저 취소한다.
-    // 취소 후에 캐시를 다시 읽어야 그 사이 도착한 응답을 밟지 않는다.
+    // 진행 중인 refetch 가 낙관적 값을 덮어쓰지 않도록 먼저 취소하고,
+    // 취소가 끝난 뒤에 캐시를 읽어야 그 사이 도착한 응답을 밟지 않는다.
     await queryClient.cancelQueries({ queryKey });
 
     const current = queryClient.getQueryData<Post>(queryKey);
     if (!current) return;
 
-    const next = !current.currentUserBookmarked;
-    if (rollbackRef.current === undefined) {
-      rollbackRef.current = current;
+    // 첫 토글 시점의 화면 값이 곧 서버 값이다 (서버에서 받아온 것이므로).
+    if (serverStateRef.current === null) {
+      serverStateRef.current = current.currentUserBookmarked;
     }
-    queryClient.setQueryData<Post>(queryKey, {
-      ...current,
-      currentUserBookmarked: next,
-    });
 
-    // 연타해도 서버로는 마지막 상태 한 번만 나간다.
+    const next = !current.currentUserBookmarked;
+    writeBookmarked(next);
+    hasPendingRef.current = true;
     sendDebounced(next);
-  }, [queryClient, queryKey, sendDebounced]);
+  }, [queryClient, queryKey, sendDebounced, writeBookmarked]);
 
-  return { toggle, isPending: mutation.isPending };
+  return { toggle };
+}
+
+/**
+ * 북마크 해제 전용. 북마크 목록에서 바로 빼기 위한 것으로, 목록의 모든 항목은
+ * 정의상 북마크된 상태라 토글이 필요 없다.
+ */
+export function useRemoveBookmark() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: number) => removeBookmark(postId),
+    onSuccess: (_data, postId) => {
+      queryClient.invalidateQueries({ queryKey: bookmarkKeys.all });
+      queryClient.invalidateQueries({ queryKey: postDetailKey(postId) });
+    },
+  });
 }

--- a/src/entities/community/model/useBookmarkMutation.ts
+++ b/src/entities/community/model/useBookmarkMutation.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useRef } from "react";
+import { useDebouncedCallback } from "@/shared/lib/useDebouncedCallback";
+import { toast } from "@/shared/ui/toast";
+import { addBookmark, removeBookmark } from "../api/bookmarkApi";
+import type { Post } from "../types";
+import { bookmarkKeys, postDetailKey } from "./bookmarkKeys";
+
+const TOGGLE_DEBOUNCE_MS = 400;
+
+/**
+ * 북마크 토글.
+ *
+ * 이 리포에서 낙관적 업데이트를 쓰는 첫 훅이다. 다른 뮤테이션은 전부
+ * `onSuccess → invalidateQueries` 한 가지인데 북마크만 다르게 가는 이유:
+ * 토글은 누른 즉시 반응해야 하고, 왕복을 기다리면 연타 시 버튼이 제멋대로 깜빡인다.
+ *
+ * 낙관적 갱신을 `onMutate` 가 아니라 클릭 시점에 하는 이유도 같다.
+ * 디바운스 때문에 `onMutate` 는 400ms 뒤에나 실행되어 화면이 그만큼 밀린다.
+ */
+export function useBookmarkToggle(postId: number) {
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(() => postDetailKey(postId), [postId]);
+
+  // 연타 한 묶음에서 "첫 클릭 직전" 상태만 보관한다. 매 클릭마다 덮어쓰면
+  // 롤백 대상이 이미 낙관적으로 바뀐 값이 되어 원래대로 못 돌아간다.
+  const rollbackRef = useRef<Post | undefined>(undefined);
+
+  const mutation = useMutation({
+    mutationFn: (bookmarked: boolean) =>
+      bookmarked ? addBookmark(postId) : removeBookmark(postId),
+    onError: () => {
+      if (rollbackRef.current) {
+        queryClient.setQueryData(queryKey, rollbackRef.current);
+      }
+      toast.error("북마크 처리에 실패했습니다.");
+    },
+    onSettled: () => {
+      rollbackRef.current = undefined;
+      // 스냅샷 복구는 즉각적인 되돌림일 뿐이고, 진짜 정답은 서버에서 다시 받는다.
+      queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: bookmarkKeys.all });
+    },
+  });
+
+  const sendDebounced = useDebouncedCallback(
+    (bookmarked: boolean) => mutation.mutate(bookmarked),
+    TOGGLE_DEBOUNCE_MS,
+  );
+
+  const toggle = useCallback(async () => {
+    // 진행 중인 refetch 가 낙관적 값을 덮어쓰지 않도록 먼저 취소한다.
+    // 취소 후에 캐시를 다시 읽어야 그 사이 도착한 응답을 밟지 않는다.
+    await queryClient.cancelQueries({ queryKey });
+
+    const current = queryClient.getQueryData<Post>(queryKey);
+    if (!current) return;
+
+    const next = !current.currentUserBookmarked;
+    if (rollbackRef.current === undefined) {
+      rollbackRef.current = current;
+    }
+    queryClient.setQueryData<Post>(queryKey, {
+      ...current,
+      currentUserBookmarked: next,
+    });
+
+    // 연타해도 서버로는 마지막 상태 한 번만 나간다.
+    sendDebounced(next);
+  }, [queryClient, queryKey, sendDebounced]);
+
+  return { toggle, isPending: mutation.isPending };
+}

--- a/src/entities/community/model/useMyBookmarks.ts
+++ b/src/entities/community/model/useMyBookmarks.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMyBookmarks } from "../api/bookmarkApi";
+import { bookmarkKeys } from "./bookmarkKeys";
+
+/**
+ * 마이페이지 "북마크한 글" 목록.
+ * 공개 목록(usePosts)과 달리 무한스크롤이 아니라 페이지 단위다 — useMyDuoPosts 와 같은 형태.
+ */
+export function useMyBookmarks(page: number = 0) {
+  return useQuery({
+    queryKey: bookmarkKeys.myList(page),
+    queryFn: () => getMyBookmarks(page),
+    staleTime: 1 * 60 * 1000,
+  });
+}

--- a/src/entities/community/types.ts
+++ b/src/entities/community/types.ts
@@ -55,6 +55,7 @@ export interface Post {
   commentCount: number;
   author: Author;
   currentUserVote: VoteType | null;
+  currentUserBookmarked: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/entities/community/ui/PostCard.tsx
+++ b/src/entities/community/ui/PostCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type { PostListItem } from "@/entities/community";
-import { POST_CATEGORY_LABELS } from "@/entities/community";
+import type { PostListItem } from "../types";
+import { POST_CATEGORY_LABELS } from "../types";
 import { Eye, MessageSquare, ThumbsUp } from "lucide-react";
 import Link from "next/link";
 import { getRelativeTime } from "@/shared/lib/date";

--- a/src/entities/duo/api/duoRequestApi.ts
+++ b/src/entities/duo/api/duoRequestApi.ts
@@ -36,6 +36,16 @@ export async function confirmDuoRequest(
   return response.data.data;
 }
 
+/** 매칭 결과 조회 — 매칭 당사자(소유자 ↔ 확정 요청자)만 호출 가능, 파트너 게임명/태그 반환 */
+export async function getDuoMatchResult(
+  postId: number,
+): Promise<MatchActionResponse> {
+  const response = await apiClient.get<ApiResponse<MatchActionResponse>>(
+    `/duo/posts/${postId}/match-result`,
+  );
+  return response.data.data;
+}
+
 export async function rejectDuoRequest(requestId: number): Promise<void> {
   await apiClient.put(`/duo/requests/${requestId}/reject`);
 }

--- a/src/entities/duo/index.ts
+++ b/src/entities/duo/index.ts
@@ -41,6 +41,7 @@ export {
   getPostRequests,
   acceptDuoRequest,
   confirmDuoRequest,
+  getDuoMatchResult,
   rejectDuoRequest,
   cancelDuoRequest,
   getMyDuoRequests,
@@ -49,6 +50,8 @@ export {
 // Hooks
 export { useDuoPosts, useMyDuoPosts, duoKeys } from "./model/useDuoPosts";
 export { useDuoPostDetail } from "./model/useDuoPostDetail";
+export { useDuoMatchResult } from "./model/useDuoMatchResult";
+export { useDuoNotifications } from "./model/useDuoNotifications";
 export {
   useCreateDuoPost,
   useUpdateDuoPost,

--- a/src/entities/duo/model/useDuoMatchResult.ts
+++ b/src/entities/duo/model/useDuoMatchResult.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { getDuoMatchResult } from "../api/duoRequestApi";
+import type { MatchActionResponse } from "../types";
+import { duoKeys } from "./useDuoPosts";
+
+/**
+ * 매칭 결과(파트너 정보) 조회. 매칭 당사자가 아닐 때 호출하면 403 이므로
+ * 소유자의 MATCHED 게시글 / 요청자의 CONFIRMED 요청에서만 `enabled` 로 켠다.
+ */
+export function useDuoMatchResult(postId: number, enabled: boolean) {
+  return useQuery<MatchActionResponse, Error>({
+    queryKey: duoKeys.matchResult(postId),
+    queryFn: () => getDuoMatchResult(postId),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/entities/duo/model/useDuoMatchResult.ts
+++ b/src/entities/duo/model/useDuoMatchResult.ts
@@ -13,5 +13,7 @@ export function useDuoMatchResult(postId: number, enabled: boolean) {
     queryFn: () => getDuoMatchResult(postId),
     enabled,
     staleTime: 5 * 60 * 1000,
+    // 비당사자는 403이 정상 응답이므로 글로벌 retry(1회)를 끈다
+    retry: false,
   });
 }

--- a/src/entities/duo/model/useDuoNotifications.ts
+++ b/src/entities/duo/model/useDuoNotifications.ts
@@ -29,11 +29,21 @@ export function useDuoNotifications(enabled: boolean) {
       queryClient.invalidateQueries({ queryKey: duoKeys.all });
     };
 
+    // 쿠키 인증이라 토큰 만료 시 EventSource 는 스스로 401→refresh 를 못 한다.
+    // 연속 오류가 임계치를 넘으면 재연결 폭주를 막기 위해 구독을 끊는다.
+    // (이후 갱신은 staleTime/페이지 재진입 시 일반 refetch 로 복구)
+    let consecutiveErrors = 0;
+    const MAX_CONSECUTIVE_ERRORS = 5;
+
     source.addEventListener("duo-notification", handleNotification);
+    source.onopen = () => {
+      consecutiveErrors = 0;
+    };
     source.onerror = () => {
-      // EventSource 는 기본적으로 자동 재연결한다. 닫힌 경우만 로깅.
-      if (source.readyState === EventSource.CLOSED) {
-        logger.warn("Duo SSE connection closed");
+      consecutiveErrors += 1;
+      if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+        logger.warn("Duo SSE 연속 오류로 구독 종료 — 새로고침 시 재연결");
+        source.close();
       }
     };
 

--- a/src/entities/duo/model/useDuoNotifications.ts
+++ b/src/entities/duo/model/useDuoNotifications.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { logger } from "@/shared/lib/logger";
+import { duoKeys } from "./useDuoPosts";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8100/api";
+
+/**
+ * 듀오 실시간 알림(SSE) 구독. 수신 이벤트(`duo-notification`: REQUEST_ACCEPTED /
+ * MATCH_CONFIRMED / REQUEST_CLOSED)마다 듀오 쿼리를 무효화해 목록·상세·내 요청을
+ * 자동 갱신한다. 쿠키 인증이므로 로그인 상태(`enabled`)에서만 연결한다.
+ * 멤버당 1연결 — 재구독 시 서버가 기존 연결을 종료한다.
+ */
+export function useDuoNotifications(enabled: boolean) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const source = new EventSource(
+      `${API_BASE_URL}/duo/notifications/subscribe`,
+      { withCredentials: true },
+    );
+
+    const handleNotification = () => {
+      queryClient.invalidateQueries({ queryKey: duoKeys.all });
+    };
+
+    source.addEventListener("duo-notification", handleNotification);
+    source.onerror = () => {
+      // EventSource 는 기본적으로 자동 재연결한다. 닫힌 경우만 로깅.
+      if (source.readyState === EventSource.CLOSED) {
+        logger.warn("Duo SSE connection closed");
+      }
+    };
+
+    return () => {
+      source.removeEventListener("duo-notification", handleNotification);
+      source.close();
+    };
+  }, [enabled, queryClient]);
+}

--- a/src/entities/duo/model/useDuoPosts.ts
+++ b/src/entities/duo/model/useDuoPosts.ts
@@ -8,6 +8,8 @@ export const duoKeys = {
   postList: (params: Omit<DuoPostFilters, "page">) =>
     [...duoKeys.posts(), params] as const,
   postDetail: (id: number) => [...duoKeys.posts(), "detail", id] as const,
+  matchResult: (postId: number) =>
+    [...duoKeys.posts(), "match-result", postId] as const,
   myPosts: () => [...duoKeys.all, "my-posts"] as const,
   myRequests: () => [...duoKeys.all, "my-requests"] as const,
 };

--- a/src/entities/duo/types.ts
+++ b/src/entities/duo/types.ts
@@ -1,6 +1,12 @@
 // === Lane ===
+/** 폼·필터에서 선택 가능한 라인 (서버 Lane enum 중 듀오에서 노출하는 5종) */
 export const LANES = ["TOP", "JUNGLE", "MID", "ADC", "SUPPORT"] as const;
-export type Lane = (typeof LANES)[number];
+/**
+ * 응답에 담길 수 있는 라인 값. 서버 Lane enum 은 FILL 을 포함하므로
+ * 타입을 넓혀 LANE_LABELS / LANE_IMAGE_KEY lookup 을 total 로 유지한다
+ * (선택 UI 에는 LANES 만 노출).
+ */
+export type Lane = (typeof LANES)[number] | "FILL";
 
 export const LANE_LABELS: Record<Lane, string> = {
   TOP: "탑",
@@ -8,6 +14,7 @@ export const LANE_LABELS: Record<Lane, string> = {
   MID: "미드",
   ADC: "원딜",
   SUPPORT: "서포터",
+  FILL: "상관없음",
 };
 
 /** Lane → 포지션 이미지 파일 키 (MID→MIDDLE, ADC→BOTTOM, SUPPORT→UTILITY) */
@@ -17,6 +24,7 @@ export const LANE_IMAGE_KEY: Record<Lane, string> = {
   MID: "MIDDLE",
   ADC: "BOTTOM",
   SUPPORT: "UTILITY",
+  FILL: "FILL",
 };
 
 // === Tier ===
@@ -41,7 +49,8 @@ export type RequestStatus =
   | "ACCEPTED"
   | "CONFIRMED"
   | "REJECTED"
-  | "CANCELLED";
+  | "CANCELLED"
+  | "CLOSED";
 
 export const POST_STATUS_LABELS: Record<PostStatus, string> = {
   ACTIVE: "모집 중",
@@ -56,6 +65,7 @@ export const REQUEST_STATUS_LABELS: Record<RequestStatus, string> = {
   CONFIRMED: "확정됨",
   REJECTED: "거절됨",
   CANCELLED: "취소됨",
+  CLOSED: "종료됨",
 };
 
 // === 챔피언 통계 ===

--- a/src/entities/duo/types.ts
+++ b/src/entities/duo/types.ts
@@ -1,12 +1,6 @@
 // === Lane ===
-/** 폼·필터에서 선택 가능한 라인 (서버 Lane enum 중 듀오에서 노출하는 5종) */
 export const LANES = ["TOP", "JUNGLE", "MID", "ADC", "SUPPORT"] as const;
-/**
- * 응답에 담길 수 있는 라인 값. 서버 Lane enum 은 FILL 을 포함하므로
- * 타입을 넓혀 LANE_LABELS / LANE_IMAGE_KEY lookup 을 total 로 유지한다
- * (선택 UI 에는 LANES 만 노출).
- */
-export type Lane = (typeof LANES)[number] | "FILL";
+export type Lane = (typeof LANES)[number];
 
 export const LANE_LABELS: Record<Lane, string> = {
   TOP: "탑",
@@ -14,7 +8,6 @@ export const LANE_LABELS: Record<Lane, string> = {
   MID: "미드",
   ADC: "원딜",
   SUPPORT: "서포터",
-  FILL: "상관없음",
 };
 
 /** Lane → 포지션 이미지 파일 키 (MID→MIDDLE, ADC→BOTTOM, SUPPORT→UTILITY) */
@@ -24,7 +17,6 @@ export const LANE_IMAGE_KEY: Record<Lane, string> = {
   MID: "MIDDLE",
   ADC: "BOTTOM",
   SUPPORT: "UTILITY",
-  FILL: "FILL",
 };
 
 // === Tier ===

--- a/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
+++ b/src/features/champion-stats-filter/ui/ChampionStatsFilters.tsx
@@ -3,7 +3,8 @@
 import { AVAILABLE_REGIONS } from "@/features/region-select";
 import { useSeasonStore } from "@/entities/season";
 import { ChevronDown } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
+import { useClickOutside } from "@/shared/lib/useClickOutside";
 import { TIER_OPTIONS } from "../lib/tiers";
 
 interface ChampionStatsFiltersProps {
@@ -34,22 +35,9 @@ export default function ChampionStatsFilters({
   const latestPatches = latestSeason?.patchVersions ?? [];
   const activePatch = selectedPatch || latestPatches[0] || "";
 
-  const handleClickOutside = useCallback((e: MouseEvent) => {
-    if (tierRef.current && !tierRef.current.contains(e.target as Node)) {
-      setTierOpen(false);
-    }
-    if (patchRef.current && !patchRef.current.contains(e.target as Node)) {
-      setPatchOpen(false);
-    }
-    if (platformRef.current && !platformRef.current.contains(e.target as Node)) {
-      setPlatformOpen(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [handleClickOutside]);
+  useClickOutside(tierRef, () => setTierOpen(false), tierOpen);
+  useClickOutside(patchRef, () => setPatchOpen(false), patchOpen);
+  useClickOutside(platformRef, () => setPlatformOpen(false), platformOpen);
 
   return (
     <div className="grid grid-cols-3 gap-2 sm:flex sm:items-center sm:justify-center sm:flex-wrap">

--- a/src/features/community-bookmark/index.ts
+++ b/src/features/community-bookmark/index.ts
@@ -1,0 +1,1 @@
+export { default as BookmarkButton } from "./ui/BookmarkButton";

--- a/src/features/community-bookmark/ui/BookmarkButton.tsx
+++ b/src/features/community-bookmark/ui/BookmarkButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Bookmark } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useAuthStore } from "@/entities/auth";
+import { useBookmarkToggle } from "@/entities/community";
+
+interface BookmarkButtonProps {
+  postId: number;
+  bookmarked: boolean;
+}
+
+export default function BookmarkButton({
+  postId,
+  bookmarked,
+}: BookmarkButtonProps) {
+  const router = useRouter();
+  const user = useAuthStore((s) => s.user);
+  const { toggle } = useBookmarkToggle(postId);
+
+  const handleClick = () => {
+    if (!user) {
+      router.push("/login");
+      return;
+    }
+    void toggle();
+  };
+
+  // 요청 중이라고 버튼을 잠그지 않는다. 디바운스로 요청은 한 번만 나가므로
+  // 잠글 이유가 없고, 잠그면 되돌리려는 클릭까지 막혀 오히려 답답해진다.
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-pressed={bookmarked}
+      className={`flex items-center gap-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors cursor-pointer ${
+        bookmarked
+          ? "bg-primary/20 text-primary border border-primary/50"
+          : "bg-surface-4 hover:bg-surface-8 border border-divider text-on-surface-medium"
+      }`}
+    >
+      <Bookmark className={`w-4 h-4 ${bookmarked ? "fill-current" : ""}`} />
+      {bookmarked ? "저장됨" : "저장"}
+    </button>
+  );
+}

--- a/src/features/community-bookmark/ui/BookmarkButton.tsx
+++ b/src/features/community-bookmark/ui/BookmarkButton.tsx
@@ -4,6 +4,7 @@ import { Bookmark } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/entities/auth";
 import { useBookmarkToggle } from "@/entities/community";
+import { toast } from "@/shared/ui/toast";
 
 interface BookmarkButtonProps {
   postId: number;
@@ -16,7 +17,11 @@ export default function BookmarkButton({
 }: BookmarkButtonProps) {
   const router = useRouter();
   const user = useAuthStore((s) => s.user);
-  const { toggle } = useBookmarkToggle(postId);
+  // 토스트는 호출부가 붙인다 — entities 훅은 UI 를 모른다
+  // (useVoteMutation 등 기존 뮤테이션과 같은 컨벤션).
+  const { toggle } = useBookmarkToggle(postId, {
+    onError: () => toast.error("북마크 처리에 실패했습니다."),
+  });
 
   const handleClick = () => {
     if (!user) {

--- a/src/features/ranking-filter/ui/RankingFilters.tsx
+++ b/src/features/ranking-filter/ui/RankingFilters.tsx
@@ -3,9 +3,10 @@
 import { useTierCutoffs } from "@/entities/ranking";
 import { AVAILABLE_REGIONS, type RegionValue } from "@/features/region-select";
 import { getTierImageUrl } from "@/shared/lib/tier";
+import { useClickOutside } from "@/shared/lib/useClickOutside";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 interface RankingFiltersProps {
   region: RegionValue;
@@ -64,27 +65,8 @@ export default function RankingFilters({
   const regionRef = useRef<HTMLDivElement>(null);
   const queueTypeRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        regionRef.current &&
-        !regionRef.current.contains(event.target as Node)
-      ) {
-        setIsRegionOpen(false);
-      }
-      if (
-        queueTypeRef.current &&
-        !queueTypeRef.current.contains(event.target as Node)
-      ) {
-        setIsQueueTypeOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
+  useClickOutside(regionRef, () => setIsRegionOpen(false), isRegionOpen);
+  useClickOutside(queueTypeRef, () => setIsQueueTypeOpen(false), isQueueTypeOpen);
 
   const selectedRegion = AVAILABLE_REGIONS.find((r) => r.value === region);
   const selectedQueueTypeLabel =

--- a/src/features/summoner-search/model/useSummonerSearch.ts
+++ b/src/features/summoner-search/model/useSummonerSearch.ts
@@ -20,8 +20,14 @@ export function useSummonerSearch() {
   const autocompleteRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const regionRef = useRef<HTMLDivElement>(null);
+  const justSelectedRef = useRef(false);
 
   useEffect(() => {
+    if (justSelectedRef.current) {
+      justSelectedRef.current = false;
+      return;
+    }
+
     const trimmedName = summonerName.trim();
 
     if (trimmedName.length < 2) {
@@ -92,6 +98,7 @@ export function useSummonerSearch() {
     const encodedName = encodeURIComponent(gameName);
     router.push(`/summoners/${region}/${encodedName}`);
     setShowAutocomplete(false);
+    justSelectedRef.current = true;
     setSummonerName(gameName);
   };
 

--- a/src/shared/lib/useClickOutside.ts
+++ b/src/shared/lib/useClickOutside.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export function useClickOutside<T extends HTMLElement>(
+  ref: React.RefObject<T | null>,
+  handler: () => void,
+  enabled: boolean = true,
+): void {
+  const handlerRef = useRef(handler);
+  useEffect(() => {
+    handlerRef.current = handler;
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handlerRef.current();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [ref, enabled]);
+}

--- a/src/shared/lib/useDebouncedCallback.ts
+++ b/src/shared/lib/useDebouncedCallback.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * 마지막 호출만 delay 후에 실행한다.
+ *
+ * 낙관적 업데이트와 짝을 이루는 토글(북마크 등)에서 필요하다. 디바운스가 없으면
+ * 연타 시 POST 와 DELETE 가 뒤바뀐 순서로 서버에 도착할 수 있고, 그러면
+ * 서버는 "북마크됨" 인데 화면은 "해제됨" 인 상태가 되어 새로고침 전까지 아무도 모른다.
+ * 서버를 멱등하게 만들어도 도착 순서 문제는 풀리지 않으므로, 요청 자체를 하나로 줄인다.
+ *
+ * 대기 중인 호출이 있는 상태로 언마운트되면 그 호출을 즉시 실행한다(flush).
+ * 사용자가 마지막으로 누른 상태가 서버에 반영되지 않은 채 페이지를 떠나면 안 된다.
+ */
+export function useDebouncedCallback<A extends unknown[]>(
+  callback: (...args: A) => void,
+  delayMs: number,
+) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingArgsRef = useRef<A | null>(null);
+  const callbackRef = useRef(callback);
+
+  // 렌더 중 ref 에 쓰지 않는다 — 최신 콜백은 커밋 후에 반영한다.
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current === null) return;
+      clearTimeout(timerRef.current);
+      const args = pendingArgsRef.current;
+      pendingArgsRef.current = null;
+      if (args) callbackRef.current(...args);
+    };
+  }, []);
+
+  return useCallback(
+    (...args: A) => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      pendingArgsRef.current = args;
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        const pending = pendingArgsRef.current;
+        pendingArgsRef.current = null;
+        if (pending) callbackRef.current(...pending);
+      }, delayMs);
+    },
+    [delayMs],
+  );
+}

--- a/src/shared/ui/game/SpellRuneImages.tsx
+++ b/src/shared/ui/game/SpellRuneImages.tsx
@@ -1,22 +1,21 @@
 "use client";
 
-import { getSpellImageUrlAsync } from "@/shared/lib/game";
+import { getSpellImageUrl } from "@/shared/lib/game";
+import { useGameDataStore } from "@/shared/model/game-data";
 import { GameTooltip } from "@/shared/ui/tooltip";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
 // 소환사 주문 이미지 컴포넌트 (비동기 로드)
 export function SummonerSpellImage({ spellId, small, size }: { spellId: number; small?: boolean; size?: "default" | "small" | "xs" | "2xs" }) {
-  const [imageUrl, setImageUrl] = useState<string>("");
+  const summonerData = useGameDataStore((s) => s.summonerData);
+  // summonerData를 의존성에 포함해 게임 데이터 hydration 시 URL을 재계산한다
+  // (getSpellImageUrl이 store를 getState로 읽어 lint가 의존성을 감지하지 못함)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const imageUrl = useMemo(() => getSpellImageUrl(spellId), [spellId, summonerData]);
   const resolvedSize = size ?? (small ? "small" : "default");
   const sizeClass = { "2xs": "w-3.5 h-3.5", xs: "w-[18px] h-[18px]", small: "w-6 h-6", default: "w-7 h-7" }[resolvedSize];
   const imgSize = { "2xs": 14, xs: 18, small: 24, default: 28 }[resolvedSize];
-
-  useEffect(() => {
-    if (spellId > 0) {
-      getSpellImageUrlAsync(spellId).then(setImageUrl).catch(() => { });
-    }
-  }, [spellId]);
 
   if (!imageUrl) {
     return null;

--- a/src/shared/ui/modal/ConfirmModal.tsx
+++ b/src/shared/ui/modal/ConfirmModal.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { Modal, type ModalSize } from "./Modal";
+
+export interface ConfirmModalProps {
+  open: boolean;
+  /** 모달 제목 */
+  title: string;
+  /** 본문. 문자열 대신 노드도 받는다. */
+  description?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** danger 는 파괴적 동작(삭제·탈퇴)용 */
+  variant?: "default" | "danger";
+  /** 처리 중. true 면 버튼이 잠기고 배경/Escape 로 닫히지 않는다. */
+  loading?: boolean;
+  size?: ModalSize;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+/**
+ * 브라우저 기본 `confirm()` 을 대체하는 확인 모달.
+ *
+ * `confirm()` 은 메인 스레드를 막고 스타일을 입힐 수 없으며 모바일에서 도메인이 노출된다.
+ */
+export function ConfirmModal({
+  open,
+  title,
+  description,
+  confirmLabel = "확인",
+  cancelLabel = "취소",
+  variant = "default",
+  loading = false,
+  size = "sm",
+  onConfirm,
+  onClose,
+}: ConfirmModalProps) {
+  const isDanger = variant === "danger";
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={title}
+      size={size}
+      showCloseButton={false}
+      closeOnBackdrop={!loading}
+      closeOnEscape={!loading}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={loading}
+            className="flex-1 py-2.5 bg-surface-4 border border-divider text-on-surface-medium rounded-lg text-sm font-medium hover:bg-surface-1 transition-colors disabled:opacity-50"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={loading}
+            className={`flex-1 py-2.5 rounded-lg text-sm font-medium text-white transition-colors disabled:opacity-50 ${
+              isDanger
+                ? "bg-error hover:bg-error/90"
+                : "bg-primary hover:bg-primary/90"
+            }`}
+          >
+            {loading ? "처리 중..." : confirmLabel}
+          </button>
+        </>
+      }
+    >
+      {description &&
+        (isDanger ? (
+          <div className="flex items-start gap-3 p-4 bg-error/10 border border-error/20 rounded-lg">
+            <AlertTriangle className="w-5 h-5 text-error shrink-0 mt-0.5" />
+            <div className="text-sm text-on-surface-medium leading-relaxed">
+              {description}
+            </div>
+          </div>
+        ) : (
+          <div className="text-sm text-on-surface-medium leading-relaxed">
+            {description}
+          </div>
+        ))}
+    </Modal>
+  );
+}

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useSyncExternalStore,
+} from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+
+export type ModalSize = "sm" | "md" | "lg" | "xl";
+
+const SIZE_CLASS: Record<ModalSize, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-2xl",
+};
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+/**
+ * 열려 있는 모달 스택.
+ *
+ * 모달은 겹칠 수 있다 (예: 상세 모달 안에서 삭제 확인 모달). 스택이 없으면
+ * (1) Escape 한 번에 모달이 전부 닫히고
+ * (2) 안쪽 모달을 닫는 순간 body 스크롤 잠금이 풀려 바깥 모달 뒤 페이지가 스크롤된다.
+ * 최상단 id 만 Escape 를 처리하고, 스택이 완전히 빌 때만 스크롤을 되돌린다.
+ */
+const openStack: string[] = [];
+let previousBodyOverflow = "";
+
+function pushModal(id: string) {
+  if (openStack.length === 0) {
+    previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  }
+  openStack.push(id);
+}
+
+function popModal(id: string) {
+  const index = openStack.lastIndexOf(id);
+  if (index !== -1) openStack.splice(index, 1);
+  if (openStack.length === 0) {
+    document.body.style.overflow = previousBodyOverflow;
+  }
+}
+
+const noopSubscribe = () => () => {};
+
+/**
+ * 클라이언트에서 마운트가 끝났는지. `createPortal` 의 대상인 document 가
+ * 서버에는 없어서 필요하다.
+ *
+ * effect + setState 대신 useSyncExternalStore 를 쓰는 이유:
+ * 하이드레이션 중에는 getServerSnapshot(false)이 쓰여 서버 결과와 일치하고,
+ * 하이드레이션 이후에 getSnapshot(true)으로 넘어간다. 불일치도, 추가 렌더 경고도 없다.
+ */
+function useHasMounted() {
+  return useSyncExternalStore(
+    noopSubscribe,
+    () => true,
+    () => false,
+  );
+}
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: React.ReactNode;
+  /** 헤더 우측 X 버튼 노출 여부 */
+  showCloseButton?: boolean;
+  /** 배경 클릭으로 닫기. 처리 중에는 false 로 내려 닫기를 막는다. */
+  closeOnBackdrop?: boolean;
+  /** Escape 로 닫기. 처리 중에는 false 로 내려 닫기를 막는다. */
+  closeOnEscape?: boolean;
+  size?: ModalSize;
+  /** 푸터 영역 (주로 액션 버튼) */
+  footer?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+/**
+ * 공용 모달 셸. 오버레이·스크롤 잠금·Escape·포커스 관리만 담당하고
+ * 내용은 children 이 채운다.
+ */
+export function Modal({
+  open,
+  onClose,
+  title,
+  showCloseButton = true,
+  closeOnBackdrop = true,
+  closeOnEscape = true,
+  size = "md",
+  footer,
+  children,
+}: ModalProps) {
+  const instanceId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const mounted = useHasMounted();
+
+  useEffect(() => {
+    if (!open) return;
+    pushModal(instanceId);
+    return () => popModal(instanceId);
+  }, [open, instanceId]);
+
+  // 열릴 때 포커스를 모달 안으로 옮기고, 닫힐 때 원래 위치로 되돌린다.
+  useEffect(() => {
+    if (!open) return;
+    restoreFocusRef.current = document.activeElement as HTMLElement | null;
+    const panel = panelRef.current;
+    const first = panel?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    (first ?? panel)?.focus();
+    return () => restoreFocusRef.current?.focus?.();
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        if (!closeOnEscape) return;
+        // 겹쳐 있을 때 최상단 모달만 반응한다.
+        if (openStack[openStack.length - 1] !== instanceId) return;
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = Array.from(
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => el.offsetParent !== null);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    },
+    [closeOnEscape, instanceId, onClose],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, handleKeyDown]);
+
+  if (!open || !mounted) return null;
+
+  const labelId = title ? `${instanceId}-title` : undefined;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center"
+      onMouseDown={(e) => {
+        // click 이 아니라 mousedown 기준. 모달 안에서 드래그를 시작해 배경에서 놓으면
+        // click 의 target 이 배경이 되어 의도치 않게 닫힌다.
+        if (closeOnBackdrop && e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelId}
+        tabIndex={-1}
+        className={`bg-surface-4 rounded-lg border border-divider w-full ${SIZE_CLASS[size]} mx-4 max-h-[90vh] overflow-y-auto p-6 outline-none`}
+      >
+        {(title || showCloseButton) && (
+          <div className="flex items-center justify-between mb-6">
+            {title ? (
+              <h2 id={labelId} className="text-lg font-bold text-on-surface">
+                {title}
+              </h2>
+            ) : (
+              <span />
+            )}
+            {showCloseButton && (
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="닫기"
+                className="text-on-surface-disabled hover:text-on-surface transition-colors disabled:opacity-50"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            )}
+          </div>
+        )}
+
+        {children}
+
+        {footer && <div className="flex gap-3 mt-6">{footer}</div>}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/shared/ui/modal/index.ts
+++ b/src/shared/ui/modal/index.ts
@@ -1,0 +1,4 @@
+export { Modal } from "./Modal";
+export type { ModalProps, ModalSize } from "./Modal";
+export { ConfirmModal } from "./ConfirmModal";
+export type { ConfirmModalProps } from "./ConfirmModal";

--- a/src/shared/ui/toast/Toaster.tsx
+++ b/src/shared/ui/toast/Toaster.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Toaster as SonnerToaster } from "sonner";
+
+/**
+ * 앱 전역 토스트 컨테이너. `app/layout.tsx` 에 한 번만 마운트한다.
+ *
+ * 색은 sonner 의 CSS 변수를 디자인 토큰으로 덮어써서 맞춘다.
+ * 토큰(`--color-surface-4` 등)이 루트의 `.dark`/`.light` 클래스를 따라 바뀌므로,
+ * 테마 스토어를 구독하지 않아도 라이트/다크가 자동으로 따라온다.
+ * (shared 레이어는 features/theme-toggle 을 import 할 수 없다 — FSD 의존 방향)
+ */
+export function Toaster() {
+  return (
+    <SonnerToaster
+      position="top-center"
+      duration={3000}
+      closeButton
+      richColors
+      style={
+        {
+          "--normal-bg": "var(--color-surface-4)",
+          "--normal-text": "var(--color-on-surface)",
+          "--normal-border": "var(--color-divider)",
+          "--success-bg": "var(--color-surface-4)",
+          "--success-text": "var(--color-success)",
+          "--success-border": "var(--color-divider)",
+          "--error-bg": "var(--color-surface-4)",
+          "--error-text": "var(--color-error)",
+          "--error-border": "var(--color-divider)",
+          "--warning-bg": "var(--color-surface-4)",
+          "--warning-text": "var(--color-warning)",
+          "--warning-border": "var(--color-divider)",
+        } as React.CSSProperties
+      }
+    />
+  );
+}

--- a/src/shared/ui/toast/index.ts
+++ b/src/shared/ui/toast/index.ts
@@ -1,0 +1,7 @@
+export { Toaster } from "./Toaster";
+
+/**
+ * 호출부는 sonner 를 직접 import 하지 않고 이 seam 을 통해 쓴다.
+ * 토스트 라이브러리를 교체할 때 바꿀 지점이 여기 하나로 모인다.
+ */
+export { toast } from "sonner";

--- a/src/widgets/champion-stats-panel/ui/ChampionListSidebar.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionListSidebar.tsx
@@ -55,7 +55,7 @@ export default function ChampionListSidebar({
           <Link
             prefetch={false}
             key={champ.id}
-            href={`/champion-stats/${champ.id}?tier=${tier}&patch=${patch}&platformId=${platformId}`}
+            href={`/champion-stats/${champ.id}?tier=${encodeURIComponent(tier)}&patch=${patch}&platformId=${platformId}`}
             className="flex flex-col items-center gap-1 p-1 rounded transition-colors text-on-surface-medium hover:bg-surface-4 hover:text-on-surface"
           >
             <Image

--- a/src/widgets/champion-stats-panel/ui/ChampionStatsTable.tsx
+++ b/src/widgets/champion-stats-panel/ui/ChampionStatsTable.tsx
@@ -114,7 +114,7 @@ export default function ChampionStatsTable({
               <Link
                 prefetch={false}
                 key={entry.championId}
-                href={`/champion-stats/${championId}?tier=${tier}&patch=${patch}&platformId=${platformId}`}
+                href={`/champion-stats/${championId}?tier=${encodeURIComponent(tier)}&patch=${patch}&platformId=${platformId}`}
                 className="grid grid-cols-[80px_60px_1fr_1fr_1fr] items-center px-4 py-2.5 hover:bg-surface-4 transition-colors border-b border-divider last:border-b-0"
               >
                 {content}

--- a/src/widgets/community-detail/ui/CommentSection.tsx
+++ b/src/widgets/community-detail/ui/CommentSection.tsx
@@ -10,7 +10,10 @@ import {
 } from "@/entities/community";
 import { useAuthStore } from "@/entities/auth";
 import { CommentForm, CommentItem } from "@/features/community-comment";
+import { ConfirmModal } from "@/shared/ui/modal";
+import { toast } from "@/shared/ui/toast";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 interface CommentSectionProps {
   postId: number;
@@ -26,6 +29,7 @@ export default function CommentSection({ postId, commentCount }: CommentSectionP
   const deleteMutation = useDeleteComment(postId);
   const voteMutation = useVote(postId);
   const removeVoteMutation = useRemoveVote(postId);
+  const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
 
   const handleCreate = (content: string) => {
     if (!user) {
@@ -48,9 +52,15 @@ export default function CommentSection({ postId, commentCount }: CommentSectionP
   };
 
   const handleDelete = (commentId: number) => {
-    if (confirm("댓글을 삭제하시겠습니까?")) {
-      deleteMutation.mutate(commentId);
-    }
+    setPendingDeleteId(commentId);
+  };
+
+  const confirmDelete = () => {
+    if (pendingDeleteId === null) return;
+    deleteMutation.mutate(pendingDeleteId, {
+      onSuccess: () => setPendingDeleteId(null),
+      onError: () => toast.error("댓글 삭제에 실패했습니다."),
+    });
   };
 
   const handleVote = (targetId: number, voteType: "UPVOTE" | "DOWNVOTE") => {
@@ -98,6 +108,17 @@ export default function CommentSection({ postId, commentCount }: CommentSectionP
           아직 댓글이 없습니다. 첫 댓글을 작성해보세요!
         </div>
       )}
+
+      <ConfirmModal
+        open={pendingDeleteId !== null}
+        title="댓글 삭제"
+        description="이 댓글을 삭제하시겠습니까? 삭제한 댓글은 되돌릴 수 없습니다."
+        confirmLabel="삭제"
+        variant="danger"
+        loading={deleteMutation.isPending}
+        onConfirm={confirmDelete}
+        onClose={() => setPendingDeleteId(null)}
+      />
     </div>
   );
 }

--- a/src/widgets/community-detail/ui/PostDetailPanel.tsx
+++ b/src/widgets/community-detail/ui/PostDetailPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { ArrowLeft, Pencil, Trash2 } from "lucide-react";
 import {
   usePostDetail,
@@ -12,6 +13,8 @@ import {
 import type { VoteType } from "@/entities/community";
 import { useAuthStore } from "@/entities/auth";
 import { VoteButtons } from "@/shared/ui/vote-buttons";
+import { ConfirmModal } from "@/shared/ui/modal";
+import { toast } from "@/shared/ui/toast";
 import { formatDate } from "@/shared/lib/date";
 import CommentSection from "./CommentSection";
 
@@ -24,6 +27,7 @@ export default function PostDetailPanel({ postId }: PostDetailPanelProps) {
   const user = useAuthStore((s) => s.user);
   const { data: post, isLoading, error } = usePostDetail(postId);
   const deleteMutation = useDeletePost();
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const voteMutation = useVote(postId);
   const removeVoteMutation = useRemoveVote(postId);
 
@@ -44,13 +48,15 @@ export default function PostDetailPanel({ postId }: PostDetailPanelProps) {
     }
   };
 
-  const handleDelete = () => {
+  const confirmDelete = () => {
     if (!post) return;
-    if (confirm("게시글을 삭제하시겠습니까?")) {
-      deleteMutation.mutate(post.id, {
-        onSuccess: () => router.push("/community"),
-      });
-    }
+    deleteMutation.mutate(post.id, {
+      onSuccess: () => {
+        setDeleteOpen(false);
+        router.push("/community");
+      },
+      onError: () => toast.error("게시글 삭제에 실패했습니다."),
+    });
   };
 
   if (isLoading) {
@@ -119,7 +125,7 @@ export default function PostDetailPanel({ postId }: PostDetailPanelProps) {
               </button>
               <button
                 type="button"
-                onClick={handleDelete}
+                onClick={() => setDeleteOpen(true)}
                 disabled={deleteMutation.isPending}
                 className="flex items-center gap-1 text-xs text-on-surface-disabled hover:text-red-400 transition-colors disabled:opacity-50 cursor-pointer"
               >
@@ -148,6 +154,17 @@ export default function PostDetailPanel({ postId }: PostDetailPanelProps) {
       <div className="bg-surface-1 border border-divider rounded-lg p-6">
         <CommentSection postId={post.id} commentCount={post.commentCount} />
       </div>
+
+      <ConfirmModal
+        open={deleteOpen}
+        title="게시글 삭제"
+        description="이 게시글을 삭제하시겠습니까? 삭제한 게시글은 되돌릴 수 없습니다."
+        confirmLabel="삭제"
+        variant="danger"
+        loading={deleteMutation.isPending}
+        onConfirm={confirmDelete}
+        onClose={() => setDeleteOpen(false)}
+      />
     </div>
   );
 }

--- a/src/widgets/community-detail/ui/PostDetailPanel.tsx
+++ b/src/widgets/community-detail/ui/PostDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
 import type { VoteType } from "@/entities/community";
 import { useAuthStore } from "@/entities/auth";
 import { VoteButtons } from "@/shared/ui/vote-buttons";
+import { BookmarkButton } from "@/features/community-bookmark";
 import { ConfirmModal } from "@/shared/ui/modal";
 import { toast } from "@/shared/ui/toast";
 import { formatDate } from "@/shared/lib/date";
@@ -140,13 +141,17 @@ export default function PostDetailPanel({ postId }: PostDetailPanelProps) {
           {post.content}
         </div>
 
-        <div className="flex justify-center">
+        <div className="flex items-center justify-between gap-4">
           <VoteButtons
             upvoteCount={post.upvoteCount}
             downvoteCount={post.downvoteCount}
             currentUserVote={post.currentUserVote}
             onVote={handleVote}
             isPending={isVotePending}
+          />
+          <BookmarkButton
+            postId={post.id}
+            bookmarked={post.currentUserBookmarked}
           />
         </div>
       </div>

--- a/src/widgets/community-list/index.ts
+++ b/src/widgets/community-list/index.ts
@@ -1,1 +1,2 @@
 export { default as CommunityListPanel } from "./ui/CommunityListPanel";
+export { default as PostCard } from "./ui/PostCard";

--- a/src/widgets/community-list/index.ts
+++ b/src/widgets/community-list/index.ts
@@ -1,2 +1,1 @@
 export { default as CommunityListPanel } from "./ui/CommunityListPanel";
-export { default as PostCard } from "./ui/PostCard";

--- a/src/widgets/community-list/ui/CommunityListPanel.tsx
+++ b/src/widgets/community-list/ui/CommunityListPanel.tsx
@@ -14,7 +14,7 @@ import {
 import type { PostCategory, PostSort, PostPeriod } from "@/entities/community";
 import { useAuthStore } from "@/entities/auth";
 import { CommunitySearchBar } from "@/features/community-search";
-import PostCard from "./PostCard";
+import { PostCard } from "@/entities/community";
 
 const CATEGORIES: (PostCategory | "ALL")[] = ["ALL", ...POST_CATEGORIES];
 const SORTS: PostSort[] = ["HOT", "NEW", "TOP"];

--- a/src/widgets/duo-list/ui/DuoListPanel.tsx
+++ b/src/widgets/duo-list/ui/DuoListPanel.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import { Plus } from "lucide-react";
 import { useAuthStore } from "@/entities/auth";
-import { useDuoPosts } from "@/entities/duo";
+import { useDuoPosts, useDuoNotifications } from "@/entities/duo";
 import type { Lane, Tier, DuoPostFilters } from "@/entities/duo";
 import { DuoFilters } from "@/features/duo-filter";
 import { DuoRegisterModal } from "@/features/duo-register";
@@ -16,6 +16,9 @@ type DuoTab = "posts" | "my-posts" | "my-requests";
 
 export default function DuoListPanel() {
   const user = useAuthStore((s) => s.user);
+
+  // 듀오 페이지 체류 중 실시간 알림 구독 → 수신 시 듀오 쿼리 자동 갱신
+  useDuoNotifications(!!user);
 
   const [activeTab, setActiveTab] = useState<DuoTab>("posts");
   const [selectedPostId, setSelectedPostId] = useState<number | null>(null);

--- a/src/widgets/duo-list/ui/DuoPostDetailModal.tsx
+++ b/src/widgets/duo-list/ui/DuoPostDetailModal.tsx
@@ -18,6 +18,7 @@ import { getTierName } from "@/shared/lib/tier";
 import { getRelativeTime } from "@/shared/lib/date";
 import { RequestActionButtons } from "@/features/duo-matching";
 import { DuoRequestModal } from "@/features/duo-request";
+import PartnerName from "./PartnerName";
 
 interface DuoPostDetailModalProps {
   postId: number | null;
@@ -244,12 +245,10 @@ function OwnerSection({
       {post.status === "MATCHED" && partner?.partnerGameName && (
         <div className="bg-primary/10 border border-primary/30 rounded-md p-3 text-sm">
           <span className="text-on-surface-medium">매칭 완료 · 파트너 </span>
-          <span className="text-primary font-medium">
-            {partner.partnerGameName}
-            <span className="text-on-surface-disabled">
-              #{partner.partnerTagLine}
-            </span>
-          </span>
+          <PartnerName
+            gameName={partner.partnerGameName}
+            tagLine={partner.partnerTagLine}
+          />
         </div>
       )}
 

--- a/src/widgets/duo-list/ui/DuoPostDetailModal.tsx
+++ b/src/widgets/duo-list/ui/DuoPostDetailModal.tsx
@@ -6,6 +6,7 @@ import { X, Mic, MicOff, Trash2, Pencil } from "lucide-react";
 import {
   useDuoPostDetail,
   useDeleteDuoPost,
+  useDuoMatchResult,
   LANE_LABELS,
   LANE_IMAGE_KEY,
   REQUEST_STATUS_LABELS,
@@ -234,8 +235,24 @@ function OwnerSection({
   onDelete: () => void;
   isDeleting: boolean;
 }) {
+  const matchResult = useDuoMatchResult(post.id, post.status === "MATCHED");
+  const partner = matchResult.data;
+
   return (
     <div className="space-y-4 border-t border-divider pt-4">
+      {/* 매칭 완료 시 파트너 정보 */}
+      {post.status === "MATCHED" && partner?.partnerGameName && (
+        <div className="bg-primary/10 border border-primary/30 rounded-md p-3 text-sm">
+          <span className="text-on-surface-medium">매칭 완료 · 파트너 </span>
+          <span className="text-primary font-medium">
+            {partner.partnerGameName}
+            <span className="text-on-surface-disabled">
+              #{partner.partnerTagLine}
+            </span>
+          </span>
+        </div>
+      )}
+
       {/* 소유자 액션 */}
       {post.status === "ACTIVE" && (
         <div className="flex gap-2">

--- a/src/widgets/duo-list/ui/DuoRequestCard.tsx
+++ b/src/widgets/duo-list/ui/DuoRequestCard.tsx
@@ -7,6 +7,7 @@ import {
   LANE_LABELS,
   LANE_IMAGE_KEY,
   REQUEST_STATUS_LABELS,
+  useDuoMatchResult,
 } from "@/entities/duo";
 import { getPositionImageUrl } from "@/shared/lib/position";
 import { getTierName } from "@/shared/lib/tier";
@@ -23,14 +24,20 @@ const STATUS_COLORS: Record<string, string> = {
   CONFIRMED: "text-primary",
   REJECTED: "text-red-400",
   CANCELLED: "text-on-surface-disabled",
+  CLOSED: "text-on-surface-disabled",
 };
 
 export default function DuoRequestCard({ request }: DuoRequestCardProps) {
   const tier = request.tier;
   const isMasterPlus = tier !== null && ["MASTER", "GRANDMASTER", "CHALLENGER"].includes(tier);
 
+  const isConfirmed = request.status === "CONFIRMED";
+  const matchResult = useDuoMatchResult(request.duoPostId, isConfirmed);
+  const partner = matchResult.data;
+
   return (
-    <div className="bg-surface-1 border border-divider rounded-lg p-3 flex items-center gap-3">
+    <div className="bg-surface-1 border border-divider rounded-lg p-3">
+      <div className="flex items-center gap-3">
       {/* 라인 아이콘 */}
       <div className="flex items-center gap-1 shrink-0">
         <Image
@@ -93,6 +100,20 @@ export default function DuoRequestCard({ request }: DuoRequestCardProps) {
           status={request.status}
         />
       </div>
+      </div>
+
+      {/* 매칭 확정 시 파트너 정보 */}
+      {isConfirmed && partner?.partnerGameName && (
+        <div className="mt-2 pt-2 border-t border-divider flex items-center gap-1.5 text-xs">
+          <span className="text-on-surface-disabled">파트너</span>
+          <span className="text-primary font-medium">
+            {partner.partnerGameName}
+            <span className="text-on-surface-disabled">
+              #{partner.partnerTagLine}
+            </span>
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/widgets/duo-list/ui/DuoRequestCard.tsx
+++ b/src/widgets/duo-list/ui/DuoRequestCard.tsx
@@ -13,6 +13,7 @@ import { getPositionImageUrl } from "@/shared/lib/position";
 import { getTierName } from "@/shared/lib/tier";
 import { getRelativeTime } from "@/shared/lib/date";
 import { RequesterActionButtons } from "@/features/duo-matching";
+import PartnerName from "./PartnerName";
 
 interface DuoRequestCardProps {
   request: DuoRequest;
@@ -106,12 +107,10 @@ export default function DuoRequestCard({ request }: DuoRequestCardProps) {
       {isConfirmed && partner?.partnerGameName && (
         <div className="mt-2 pt-2 border-t border-divider flex items-center gap-1.5 text-xs">
           <span className="text-on-surface-disabled">파트너</span>
-          <span className="text-primary font-medium">
-            {partner.partnerGameName}
-            <span className="text-on-surface-disabled">
-              #{partner.partnerTagLine}
-            </span>
-          </span>
+          <PartnerName
+            gameName={partner.partnerGameName}
+            tagLine={partner.partnerTagLine}
+          />
         </div>
       )}
     </div>

--- a/src/widgets/duo-list/ui/PartnerName.tsx
+++ b/src/widgets/duo-list/ui/PartnerName.tsx
@@ -1,0 +1,16 @@
+interface PartnerNameProps {
+  gameName: string;
+  tagLine: string | null;
+}
+
+/** 매칭 파트너 게임명#태그라인 표시. tagLine 이 null 이면 '#' 없이 게임명만 렌더. */
+export default function PartnerName({ gameName, tagLine }: PartnerNameProps) {
+  return (
+    <span className="text-primary font-medium">
+      {gameName}
+      {tagLine && (
+        <span className="text-on-surface-disabled">#{tagLine}</span>
+      )}
+    </span>
+  );
+}

--- a/src/widgets/home-sections/ui/DesktopAppSection.tsx
+++ b/src/widgets/home-sections/ui/DesktopAppSection.tsx
@@ -1,41 +1,24 @@
 "use client";
 
-import { useChampionRotate, getChampionImageUrl, getChampionsByIds } from "@/entities/champion";
+import {
+  useChampionRotate,
+  getChampionImageUrl,
+  useChampionsByIds,
+} from "@/entities/champion";
 import Image from "next/image";
-import { useEffect, useState } from "react";
-
-interface ChampionData {
-  id: string;
-  key: string;
-  name: string;
-  title: string;
-  image: {
-    full: string;
-  };
-}
 
 export default function DesktopAppSection() {
   const { data: rotationData, isLoading } = useChampionRotate("kr");
-  const [champions, setChampions] = useState<ChampionData[]>([]);
-  const [hasLoadedChampions, setHasLoadedChampions] = useState(false);
+  const champions = useChampionsByIds(rotationData?.freeChampionIds ?? []);
 
-  useEffect(() => {
-    if (
-      rotationData?.freeChampionIds &&
-      rotationData.freeChampionIds.length > 0
-    ) {
-      getChampionsByIds(rotationData.freeChampionIds)
-        .then(setChampions)
-        .finally(() => setHasLoadedChampions(true));
-    }
-  }, [rotationData]);
+  const hasFreeChampions =
+    !!rotationData?.freeChampionIds &&
+    rotationData.freeChampionIds.length > 0;
 
-  // rotationData가 있고 아직 로드 완료되지 않았으면 로딩 중
+  // rotation 쿼리가 로딩 중이거나, 무료 챔피언 ID는 있는데
+  // 아직 챔피언 데이터가 파생되지 않았으면 로딩 중
   const isChampionsLoading =
-    !isLoading &&
-    rotationData?.freeChampionIds &&
-    rotationData.freeChampionIds.length > 0 &&
-    !hasLoadedChampions;
+    !isLoading && hasFreeChampions && champions.length === 0;
 
   return (
     <div>

--- a/src/widgets/ingame/ui/BannedChampions.tsx
+++ b/src/widgets/ingame/ui/BannedChampions.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import type { SpectatorBannedChampion } from "@/entities/spectator";
-import { getChampionById } from "@/entities/champion";
+import { useChampionsByIds } from "@/entities/champion";
 import { getChampionImageUrl } from "@/entities/champion";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
 interface BannedChampionsProps {
   bannedChampions: SpectatorBannedChampion[];
@@ -22,30 +22,39 @@ export default function BannedChampions({
   bannedChampions,
   align = "left",
 }: BannedChampionsProps) {
-  const [bannedInfo, setBannedInfo] = useState<BannedChampionInfo[]>([]);
+  const championIds = useMemo(
+    () =>
+      bannedChampions
+        .filter((ban) => ban.championId !== -1)
+        .map((ban) => ban.championId),
+    [bannedChampions]
+  );
+  const champions = useChampionsByIds(championIds);
 
-  useEffect(() => {
-    const loadBannedChampions = async () => {
-      const info = await Promise.all(
-        bannedChampions.map(async (ban) => {
-          if (ban.championId === -1) {
-            return {
-              ...ban,
-              championName: undefined,
-            };
-          }
-          const champion = await getChampionById(ban.championId);
-          return {
-            ...ban,
-            championName: champion?.id, // id 필드 사용 (영문 이름)
-          };
-        })
-      );
-      setBannedInfo(info.sort((a, b) => a.pickTurn - b.pickTurn));
-    };
+  const championByKey = useMemo(() => {
+    const map = new Map<string, (typeof champions)[number]>();
+    for (const champion of champions) {
+      map.set(champion.key, champion);
+    }
+    return map;
+  }, [champions]);
 
-    loadBannedChampions();
-  }, [bannedChampions]);
+  const bannedInfo = useMemo<BannedChampionInfo[]>(() => {
+    const info = bannedChampions.map((ban) => {
+      if (ban.championId === -1) {
+        return {
+          ...ban,
+          championName: undefined,
+        };
+      }
+      const champion = championByKey.get(String(ban.championId));
+      return {
+        ...ban,
+        championName: champion?.id, // id 필드 사용 (영문 이름)
+      };
+    });
+    return info.sort((a, b) => a.pickTurn - b.pickTurn);
+  }, [bannedChampions, championByKey]);
 
   return (
     <div

--- a/src/widgets/ingame/ui/IngamePlayer.tsx
+++ b/src/widgets/ingame/ui/IngamePlayer.tsx
@@ -2,10 +2,11 @@
 
 import { GameTooltip } from "@/shared/ui/tooltip";
 import type { SpectatorParticipant } from "@/entities/spectator";
-import { getChampionById, getChampionImageUrl } from "@/entities/champion";
-import { getPerkImageUrl, getSpellImageUrlAsync } from "@/shared/lib/game";
+import { getChampionImageUrl, useChampionById } from "@/entities/champion";
+import { getPerkImageUrl, getSpellImageUrl } from "@/shared/lib/game";
+import { useGameDataStore } from "@/shared/model/game-data";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
 interface IngamePlayerProps {
   participant: SpectatorParticipant;
@@ -14,35 +15,16 @@ interface IngamePlayerProps {
 export default function IngamePlayer({
   participant,
 }: IngamePlayerProps) {
-  const [champId, setChampId] = useState<string>("");
-  const [champName, setChampName] = useState<string>("");
-  const [spell1Url, setSpell1Url] = useState<string>("");
-  const [spell2Url, setSpell2Url] = useState<string>("");
+  const champion = useChampionById(participant.championId);
+  const champId = champion?.id ?? ""; // 이미지 URL용 (영문 이름)
+  const champName = champion?.name ?? ""; // 표시용 (한글 이름)
 
-  useEffect(() => {
-    const loadChampion = async () => {
-      const champion = await getChampionById(participant.championId);
-      if (champion) {
-        setChampId(champion.id); // 이미지 URL용 (영문 이름)
-        setChampName(champion.name); // 표시용 (한글 이름)
-      }
-    };
-    loadChampion();
-  }, [participant.championId]);
-
-  useEffect(() => {
-    const loadSpellUrls = async () => {
-      if (participant.spell1Id > 0) {
-        const url = await getSpellImageUrlAsync(participant.spell1Id);
-        setSpell1Url(url);
-      }
-      if (participant.spell2Id > 0) {
-        const url = await getSpellImageUrlAsync(participant.spell2Id);
-        setSpell2Url(url);
-      }
-    };
-    loadSpellUrls();
-  }, [participant.spell1Id, participant.spell2Id]);
+  // getSpellImageUrl은 store.getState() 간접참조라 비반응형 → summonerData 구독으로 hydration 갱신
+  const summonerData = useGameDataStore((s) => s.summonerData);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const spell1Url = useMemo(() => getSpellImageUrl(participant.spell1Id), [participant.spell1Id, summonerData]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const spell2Url = useMemo(() => getSpellImageUrl(participant.spell2Id), [participant.spell2Id, summonerData]);
 
   const championImageUrl = champId
     ? getChampionImageUrl(champId)

--- a/src/widgets/layout/ui/Header.tsx
+++ b/src/widgets/layout/ui/Header.tsx
@@ -3,8 +3,14 @@
 import Link from "next/link";
 import Image from "next/image";
 import { ThemeToggle } from "@/features/theme-toggle";
+import { useLogout } from "@/features/auth";
+import { useAuthStore } from "@/entities/auth";
+import { useHasHydrated } from "@/shared/lib/useHasHydrated";
 
 export default function Header() {
+  const user = useAuthStore((s) => s.user);
+  const hasHydrated = useHasHydrated(useAuthStore);
+  const { handleLogout } = useLogout();
 
   return (
     <header className="bg-surface-1 border-b border-divider">
@@ -25,6 +31,29 @@ export default function Header() {
             </div>
             <div className="flex items-center gap-4">
               <ThemeToggle />
+              {!hasHydrated ? null : user ? (
+                <>
+                  <Link
+                    href="/mypage"
+                    className="text-on-surface-medium hover:text-on-surface"
+                  >
+                    {user.nickname}
+                  </Link>
+                  <button
+                    onClick={handleLogout}
+                    className="text-on-surface-medium hover:text-on-surface"
+                  >
+                    로그아웃
+                  </button>
+                </>
+              ) : (
+                <Link
+                  href="/login"
+                  className="text-on-surface-medium hover:text-on-surface"
+                >
+                  로그인
+                </Link>
+              )}
             </div>
           </div>
         </div>

--- a/src/widgets/layout/ui/Navigation.tsx
+++ b/src/widgets/layout/ui/Navigation.tsx
@@ -17,7 +17,7 @@ export default function Navigation() {
     { label: "랭킹", href: "/leaderboards" },
     { label: "패치노트", href: "/patch-notes" },
     // { label: "커뮤니티", href: "/community" },
-    // { label: "듀오 찾기", href: "/duo" },
+    { label: "듀오 찾기", href: "/duo" },
   ];
 
   return (

--- a/src/widgets/layout/ui/Navigation.tsx
+++ b/src/widgets/layout/ui/Navigation.tsx
@@ -16,7 +16,7 @@ export default function Navigation() {
     { label: "챔피언 분석", href: "/champion-stats" },
     { label: "랭킹", href: "/leaderboards" },
     { label: "패치노트", href: "/patch-notes" },
-    // { label: "커뮤니티", href: "/community" },
+    { label: "커뮤니티", href: "/community" },
     { label: "듀오 찾기", href: "/duo" },
   ];
 

--- a/src/widgets/layout/ui/Navigation.tsx
+++ b/src/widgets/layout/ui/Navigation.tsx
@@ -13,9 +13,9 @@ export default function Navigation() {
 
   const navItems = [
     { label: "홈", href: "/" },
-    { label: "챔피언 분석", href: "/champion-stats" },
+    // { label: "챔피언 분석", href: "/champion-stats" },
     { label: "랭킹", href: "/leaderboards" },
-    { label: "패치노트", href: "/patch-notes" },
+    // { label: "패치노트", href: "/patch-notes" },
     { label: "커뮤니티", href: "/community" },
     { label: "듀오 찾기", href: "/duo" },
   ];

--- a/src/widgets/mypage-panel/ui/BookmarksSection.tsx
+++ b/src/widgets/mypage-panel/ui/BookmarksSection.tsx
@@ -1,13 +1,21 @@
 "use client";
 
 import { useState } from "react";
-import { useMyBookmarks } from "@/entities/community";
-import { PostCard } from "@/widgets/community-list";
+import { BookmarkX } from "lucide-react";
+import { PostCard, useMyBookmarks, useRemoveBookmark } from "@/entities/community";
+import { toast } from "@/shared/ui/toast";
 
 export default function BookmarksSection() {
   const [page, setPage] = useState(0);
-  const { data, isLoading, isFetching } = useMyBookmarks(page);
+  const { data, isLoading, isError, isFetching, refetch } = useMyBookmarks(page);
+  const removeMutation = useRemoveBookmark();
   const posts = data?.content ?? [];
+
+  const handleRemove = (postId: number) => {
+    removeMutation.mutate(postId, {
+      onError: () => toast.error("북마크 해제에 실패했습니다."),
+    });
+  };
 
   return (
     <section>
@@ -22,21 +30,50 @@ export default function BookmarksSection() {
             />
           ))}
         </div>
+      ) : isError ? (
+        /* 실패를 빈 목록으로 보여주면 북마크가 전부 날아간 것처럼 읽힌다. */
+        <div className="text-center py-16">
+          <p className="text-on-surface-medium mb-4">
+            북마크를 불러오지 못했습니다.
+          </p>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            disabled={isFetching}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-surface-4 border border-divider text-on-surface hover:bg-surface-8 transition-colors disabled:opacity-50 cursor-pointer"
+          >
+            {isFetching ? "불러오는 중..." : "다시 시도"}
+          </button>
+        </div>
       ) : posts.length === 0 ? (
         <div className="text-center py-16 text-on-surface-disabled">
-          {page === 0
-            ? "북마크한 글이 없습니다"
-            : "이 페이지에는 글이 없습니다"}
+          {page === 0 ? "북마크한 글이 없습니다" : "이 페이지에는 글이 없습니다"}
         </div>
       ) : (
         <div className="space-y-2">
           {posts.map((post) => (
-            <PostCard key={post.id} post={post} />
+            /* 해제 버튼은 PostCard(<Link>) 안이 아니라 형제로 둔다.
+               링크 안에 버튼을 중첩하면 클릭이 서로 먹고 stopPropagation 에 의존하게 된다. */
+            <div key={post.id} className="flex items-start gap-2">
+              <div className="flex-1 min-w-0">
+                <PostCard post={post} />
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRemove(post.id)}
+                disabled={removeMutation.isPending}
+                aria-label="북마크 해제"
+                title="북마크 해제"
+                className="shrink-0 p-2 mt-1 rounded-md text-on-surface-disabled hover:text-error hover:bg-surface-4 transition-colors disabled:opacity-50 cursor-pointer"
+              >
+                <BookmarkX className="w-4 h-4" />
+              </button>
+            </div>
           ))}
         </div>
       )}
 
-      {(page > 0 || data?.hasNext) && (
+      {!isError && (page > 0 || data?.hasNext) && (
         <div className="flex items-center justify-center gap-2 mt-6">
           <button
             type="button"
@@ -46,9 +83,7 @@ export default function BookmarksSection() {
           >
             이전
           </button>
-          <span className="text-sm text-on-surface-disabled px-2">
-            {page + 1}
-          </span>
+          <span className="text-sm text-on-surface-disabled px-2">{page + 1}</span>
           <button
             type="button"
             onClick={() => setPage((p) => p + 1)}

--- a/src/widgets/mypage-panel/ui/BookmarksSection.tsx
+++ b/src/widgets/mypage-panel/ui/BookmarksSection.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { useMyBookmarks } from "@/entities/community";
+import { PostCard } from "@/widgets/community-list";
+
+export default function BookmarksSection() {
+  const [page, setPage] = useState(0);
+  const { data, isLoading, isFetching } = useMyBookmarks(page);
+  const posts = data?.content ?? [];
+
+  return (
+    <section>
+      <h2 className="text-lg font-bold text-on-surface mb-6">북마크한 글</h2>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="bg-surface-1 border border-divider rounded-lg p-4 animate-pulse h-[92px]"
+            />
+          ))}
+        </div>
+      ) : posts.length === 0 ? (
+        <div className="text-center py-16 text-on-surface-disabled">
+          {page === 0
+            ? "북마크한 글이 없습니다"
+            : "이 페이지에는 글이 없습니다"}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} />
+          ))}
+        </div>
+      )}
+
+      {(page > 0 || data?.hasNext) && (
+        <div className="flex items-center justify-center gap-2 mt-6">
+          <button
+            type="button"
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0 || isFetching}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-surface-4 border border-divider text-on-surface-medium hover:bg-surface-8 transition-colors disabled:opacity-50 cursor-pointer"
+          >
+            이전
+          </button>
+          <span className="text-sm text-on-surface-disabled px-2">
+            {page + 1}
+          </span>
+          <button
+            type="button"
+            onClick={() => setPage((p) => p + 1)}
+            disabled={!data?.hasNext || isFetching}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-surface-4 border border-divider text-on-surface-medium hover:bg-surface-8 transition-colors disabled:opacity-50 cursor-pointer"
+          >
+            다음
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/widgets/mypage-panel/ui/MypagePanel.tsx
+++ b/src/widgets/mypage-panel/ui/MypagePanel.tsx
@@ -4,7 +4,8 @@ import { Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import MypageSidebar from "./MypageSidebar";
 import AccountSection from "./AccountSection";
-export type Tab = "account";
+import BookmarksSection from "./BookmarksSection";
+export type Tab = "account" | "bookmarks";
 
 function MypagePanelContent() {
   const searchParams = useSearchParams();
@@ -20,6 +21,7 @@ function MypagePanelContent() {
       <MypageSidebar activeTab={tab} onTabChange={handleTabChange} />
       <div className="flex-1 min-w-0">
         {tab === "account" && <AccountSection />}
+        {tab === "bookmarks" && <BookmarksSection />}
       </div>
     </div>
   );

--- a/src/widgets/mypage-panel/ui/MypageSidebar.tsx
+++ b/src/widgets/mypage-panel/ui/MypageSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LogOut, User } from "lucide-react";
+import { Bookmark, LogOut, User } from "lucide-react";
 import { useLogout } from "@/features/auth";
 import type { Tab } from "./MypagePanel";
 
@@ -11,6 +11,7 @@ interface MypageSidebarProps {
 
 const tabs: { key: Tab; label: string; icon: typeof User }[] = [
   { key: "account", label: "계정 관리", icon: User },
+  { key: "bookmarks", label: "북마크한 글", icon: Bookmark },
 ];
 
 export default function MypageSidebar({

--- a/src/widgets/summoner-profile/ui/ChampionStats.tsx
+++ b/src/widgets/summoner-profile/ui/ChampionStats.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { useChampionRanking } from "@/entities/match";
-import { useGameDataStore } from "@/shared/model/game-data";
 import { GameTooltip } from "@/shared/ui/tooltip";
 import {
   getChampionImageUrl,
 } from "@/entities/champion";
 import Image from "next/image";
 import { useSeasonStore } from "@/entities/season";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 interface ChampionStatsProps {
   puuid?: string | null;
@@ -38,12 +37,6 @@ export default function ChampionStats({
 
   const [sortField, setSortField] = useState<SortField>("playCount");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
-
-  // champion.json 데이터 로드
-  const loadChampionData = useGameDataStore((state) => state.loadChampionData);
-  useEffect(() => {
-    loadChampionData();
-  }, [loadChampionData]);
 
   // limit이 있으면 제한
   const displayedStats = limit ? championStats.slice(0, limit) : championStats;

--- a/src/widgets/summoner-profile/ui/ChampionStatsOverview.tsx
+++ b/src/widgets/summoner-profile/ui/ChampionStatsOverview.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { useChampionRanking } from "@/entities/match";
-import { useGameDataStore } from "@/shared/model/game-data";
 import { GameTooltip } from "@/shared/ui/tooltip";
 import { getChampionImageUrl, getChampionNameByEnglishName } from "@/entities/champion";
 import { calcWinRateCeil2, getWinRateTextClass } from "@/entities/champion";
 import { getKDAColorClass } from "@/shared/lib/game";
 import { useSeasonStore } from "@/entities/season";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 type QueueTabType = "solo" | "flex";
 
@@ -41,12 +40,6 @@ export default function ChampionStatsOverview({
   );
 
   const championStats = data?.[activeQueue] ?? [];
-
-  // champion.json 데이터 로드 (zustand store 사용)
-  const loadChampionData = useGameDataStore((state) => state.loadChampionData);
-  useEffect(() => {
-    loadChampionData();
-  }, [loadChampionData]);
 
   // limit이 있으면 제한
   const displayedStats = limit ? championStats.slice(0, limit) : championStats;

--- a/src/widgets/summoner-profile/ui/ProfileSection.tsx
+++ b/src/widgets/summoner-profile/ui/ProfileSection.tsx
@@ -12,7 +12,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { RefreshCw } from "lucide-react";
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 interface ProfileSectionProps {
   summonerName: string; // gameName 형식: "name-tagLine"
@@ -45,12 +45,8 @@ export default function ProfileSection({
   const [isPolling, setIsPolling] = useState(false);
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const pollingStartTimeRef = useRef<number | null>(null);
-  const [cooldownInfo, setCooldownInfo] = useState<{
-    remainingSeconds: number;
-  } | null>(null);
   const [refreshError, setRefreshError] = useState<string | null>(null);
-  const [elapsedText, setElapsedText] = useState<string | null>(null);
-  const [cooldownReady, setCooldownReady] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
 
   // 컴포넌트 언마운트 시 폴링 정리
   useEffect(() => {
@@ -63,50 +59,48 @@ export default function ProfileSection({
   }, []);
 
   // 쿨다운 (2분) 계산 - 서버의 lastRevisionDateTime 기준
+  // lastRevisionClickDateTime이 있을 때만 1초마다 now를 갱신해 재계산을 트리거한다.
   useEffect(() => {
-    const updateCooldownInfo = () => {
-      if (!profileData?.lastRevisionClickDateTime) {
-        setCooldownInfo(null);
-        setElapsedText(null);
-        if (!cooldownReady) setCooldownReady(true);
-        return;
-      }
-
-      const raw = profileData.lastRevisionClickDateTime;
-      const lastRevisionTime = dayjs(raw.replace(' ', 'T') + '+09:00').valueOf();
-      const elapsed = Date.now() - lastRevisionTime;
-      const remaining = Math.max(0, 120000 - elapsed);
-
-      if (remaining > 0) {
-        setCooldownInfo({ remainingSeconds: Math.ceil(remaining / 1000) });
-      } else {
-        setCooldownInfo(null);
-      }
-
-      // 상대 시간 텍스트 계산
-      const elapsedMinutes = Math.floor(elapsed / 60000);
-      const elapsedHours = Math.floor(elapsed / 3600000);
-      const elapsedDays = Math.floor(elapsed / 86400000);
-
-      let timeText: string;
-      if (elapsedMinutes < 1) {
-        timeText = '1분 미만';
-      } else if (elapsedMinutes < 60) {
-        timeText = `${elapsedMinutes}분 전`;
-      } else if (elapsedHours < 24) {
-        timeText = `${elapsedHours}시간 전`;
-      } else {
-        timeText = `${elapsedDays}일 전`;
-      }
-
-      setElapsedText(timeText);
-      if (!cooldownReady) setCooldownReady(true);
-    };
-
-    updateCooldownInfo();
-    const interval = setInterval(updateCooldownInfo, 1000);
+    if (!profileData?.lastRevisionClickDateTime) return;
+    const interval = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(interval);
-  }, [profileData?.lastRevisionClickDateTime, cooldownReady]);
+  }, [profileData?.lastRevisionClickDateTime]);
+
+  // now + lastRevisionClickDateTime 기준으로 렌더 중 파생값 계산
+  const { cooldownInfo, elapsedText } = useMemo<{
+    cooldownInfo: { remainingSeconds: number } | null;
+    elapsedText: string | null;
+  }>(() => {
+    if (!profileData?.lastRevisionClickDateTime) {
+      return { cooldownInfo: null, elapsedText: null };
+    }
+
+    const raw = profileData.lastRevisionClickDateTime;
+    const lastRevisionTime = dayjs(raw.replace(' ', 'T') + '+09:00').valueOf();
+    const elapsed = now - lastRevisionTime;
+    const remaining = Math.max(0, 120000 - elapsed);
+
+    const cooldownInfo =
+      remaining > 0 ? { remainingSeconds: Math.ceil(remaining / 1000) } : null;
+
+    // 상대 시간 텍스트 계산
+    const elapsedMinutes = Math.floor(elapsed / 60000);
+    const elapsedHours = Math.floor(elapsed / 3600000);
+    const elapsedDays = Math.floor(elapsed / 86400000);
+
+    let elapsedText: string;
+    if (elapsedMinutes < 1) {
+      elapsedText = '1분 미만';
+    } else if (elapsedMinutes < 60) {
+      elapsedText = `${elapsedMinutes}분 전`;
+    } else if (elapsedHours < 24) {
+      elapsedText = `${elapsedHours}시간 전`;
+    } else {
+      elapsedText = `${elapsedDays}일 전`;
+    }
+
+    return { cooldownInfo, elapsedText };
+  }, [profileData?.lastRevisionClickDateTime, now]);
 
   // 에러 메시지 5초 후 자동 소멸
   useEffect(() => {
@@ -117,7 +111,6 @@ export default function ProfileSection({
 
   // 갱신 버튼 비활성화 여부 확인
   const isRefreshDisabled = () => {
-    if (!cooldownReady) return true;
     if (isRefreshing || isPolling) return true;
     if (cooldownInfo !== null) return true;
     return false;

--- a/src/widgets/summoner-profile/ui/ProfileSection.tsx
+++ b/src/widgets/summoner-profile/ui/ProfileSection.tsx
@@ -46,7 +46,9 @@ export default function ProfileSection({
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const pollingStartTimeRef = useRef<number | null>(null);
   const [refreshError, setRefreshError] = useState<string | null>(null);
-  const [now, setNow] = useState(() => Date.now());
+  // SSR/hydration 첫 렌더에서는 시간 계산을 하지 않기 위해 null로 시작한다.
+  // 실제 시간 카운트는 마운트 후 클라이언트에서만 진행 (아래 useEffect에서 setNow).
+  const [now, setNow] = useState<number | null>(null);
 
   // 컴포넌트 언마운트 시 폴링 정리
   useEffect(() => {
@@ -59,10 +61,13 @@ export default function ProfileSection({
   }, []);
 
   // 쿨다운 (2분) 계산 - 서버의 lastRevisionDateTime 기준
-  // lastRevisionClickDateTime이 있을 때만 1초마다 now를 갱신해 재계산을 트리거한다.
+  // lastRevisionClickDateTime이 있을 때만 마운트 직후 now를 세팅하고
+  // 1초마다 갱신해 재계산을 트리거한다. (실제 시간 카운트는 클라이언트 사이드에서만)
   useEffect(() => {
     if (!profileData?.lastRevisionClickDateTime) return;
-    const interval = setInterval(() => setNow(Date.now()), 1000);
+    const updateNow = () => setNow(Date.now());
+    updateNow(); // 마운트 직후 즉시 1회 계산
+    const interval = setInterval(updateNow, 1000);
     return () => clearInterval(interval);
   }, [profileData?.lastRevisionClickDateTime]);
 
@@ -71,7 +76,8 @@ export default function ProfileSection({
     cooldownInfo: { remainingSeconds: number } | null;
     elapsedText: string | null;
   }>(() => {
-    if (!profileData?.lastRevisionClickDateTime) {
+    // now === null 이면 아직 마운트 전(서버/hydration 첫 렌더)이므로 계산하지 않는다.
+    if (!profileData?.lastRevisionClickDateTime || now === null) {
       return { cooldownInfo: null, elapsedText: null };
     }
 


### PR DESCRIPTION
## Summary

- `develop` 에 누적된 8개 PR (커밋 12개) 을 `main` 으로 릴리즈합니다.
- 듀오 찾기 API 전체 연동, 커뮤니티 북마크, 공통 Toast/Modal 인프라가 주요 신규 기능이며 프로필 hydration mismatch · champion-stats 라우팅 버그픽스가 함께 포함됩니다.
- 코드 변경은 51개 파일 (+1218 / -222).

## Changes

- **듀오 찾기 API 연동** (#181) — `entities/duo` 에 match-result 조회 · SSE 실시간 알림 (`useDuoNotifications`) · CLOSED 상태 추가, 네비게이션에 듀오 메뉴 노출, 헤더에 로그인/로그아웃/마이페이지 진입 복원. SSE 재연결 폭주 방지, 파트너 태그라인 null 처리, match-result 403 retry 차단 반영.
- **커뮤니티 북마크** (#187) — `entities/community` 북마크 API/쿼리키/뮤테이션, `features/community-bookmark` 의 `BookmarkButton`, 마이페이지 `BookmarksSection`. 적대적 리뷰 지적을 반영해 토글 낙관적 업데이트 재설계.
- **공통 Toast/Modal 인프라** (#186) — `shared/ui/modal` (`Modal`, `ConfirmModal`), `shared/ui/toast` (`Toaster`), `shared/lib` 의 `useClickOutside` · `useDebouncedCallback` 추가.
- **네비게이션 메뉴 노출 조정** (#188, #189) — 커뮤니티 메뉴 활성화, 챔피언 분석 · 패치노트 메뉴 비활성화.
- **fix: 프로필 갱신 쿨다운 hydration mismatch** (#184) — `ProfileSection` 카운트다운의 SSR/CSR 불일치 수정.
- **fix: MP-80 champion-stats 라우팅** (#178) — list → detail 이동 시 tier + suffix 파라미터 보존.
- **refactor: 불필요한 useState/useEffect 제거** (#180) — 필터/인게임 위젯에서 파생 상태를 렌더 시점 계산으로 대체 (Vercel best practices).

## Notes

- **릴리즈 PR 이라 `Closes MP-<번호>` 를 넣지 않았습니다.** 개별 이슈는 각 feature PR 머지 시점에 이미 전이되며, 여기서 다시 참조하면 중복 전이가 발생합니다.
- `main` 에는 이 브랜치에 없는 커밋 4개 (release-please 1.11.0 릴리즈 커밋 및 과거 develop 머지) 가 있습니다. 머지 방식에 따라 release-please 흐름과 충돌하지 않는지 확인이 필요합니다.
- 스키마/마이그레이션 변경은 없고, 새 환경변수도 없습니다. 백엔드 듀오 API (match-result, SSE 알림 엔드포인트) 가 prod 에 배포되어 있어야 듀오 기능이 정상 동작합니다.
- 의존성 1건 추가: `sonner@^2.0.7` (Toast 인프라).

🤖 Generated by Padosol
