### PR TITLE
[MP-XXX] feat: 듀오 찾기 탭·문구 명칭 정리

### DIFF
--- a/src/widgets/duo-list/ui/DuoListPanel.tsx
+++ b/src/widgets/duo-list/ui/DuoListPanel.tsx
@@ -42,8 +42,8 @@ export default function DuoListPanel() {
   );
 
   const tabs: { key: DuoTab; label: string; requireAuth: boolean }[] = [
-    { key: "posts", label: "게시글 목록", requireAuth: false },
-    { key: "my-posts", label: "내 게시글", requireAuth: true },
+    { key: "posts", label: "듀오 목록", requireAuth: false },
+    { key: "my-posts", label: "내 등록", requireAuth: true },
     { key: "my-requests", label: "내 요청", requireAuth: true },
   ];
 

--- a/src/widgets/duo-list/ui/DuoPostDetailModal.tsx
+++ b/src/widgets/duo-list/ui/DuoPostDetailModal.tsx
@@ -54,7 +54,7 @@ export default function DuoPostDetailModal({
   if (postId === null) return null;
 
   const handleDelete = () => {
-    if (!confirm("게시글을 삭제하시겠습니까?")) return;
+    if (!confirm("듀오 등록을 삭제하시겠습니까?")) return;
     deletePost.mutate(postId, {
       onSuccess: () => onClose(),
     });
@@ -71,7 +71,7 @@ export default function DuoPostDetailModal({
         <div className="bg-surface-4 rounded-lg border border-divider w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto p-6">
           {/* 헤더 */}
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-lg font-bold text-on-surface">게시글 상세</h2>
+            <h2 className="text-lg font-bold text-on-surface">듀오 상세</h2>
             <button
               type="button"
               onClick={onClose}
@@ -98,7 +98,7 @@ export default function DuoPostDetailModal({
             />
           ) : (
             <p className="text-on-surface-disabled text-center py-8">
-              게시글을 찾을 수 없습니다
+              듀오 정보를 찾을 수 없습니다
             </p>
           )}
         </div>

--- a/src/widgets/duo-list/ui/MyDuoPostsPanel.tsx
+++ b/src/widgets/duo-list/ui/MyDuoPostsPanel.tsx
@@ -30,7 +30,7 @@ export default function MyDuoPostsPanel({
   if (posts.length === 0) {
     return (
       <div className="text-center py-16 text-on-surface-disabled">
-        작성한 게시글이 없습니다
+        등록한 듀오가 없습니다
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- 듀오 찾기 화면의 「게시글」 표현을 도메인 용어로 통일해 게시판 뉘앙스를 제거
- 탭을 `듀오 목록 / 내 등록 / 내 요청` 으로 정리. 「내 등록」은 헤더의 `듀오 등록` 버튼과 1:1 대응하고, 옆 탭 「내 요청」과 대칭 구조(내가 올린 것 ↔ 내가 보낸 것)를 이룸
- 빈 상태·상세 모달 문구도 같은 용어로 맞춰 UI 전반에서 「게시글」 노출 제거

## Changes
- `src/widgets/duo-list/ui/DuoListPanel.tsx` — 탭 라벨 2건: 게시글 목록 → 듀오 목록, 내 게시글 → 내 등록
- `src/widgets/duo-list/ui/MyDuoPostsPanel.tsx` — 빈 상태: "작성한 게시글이 없습니다" → "등록한 듀오가 없습니다"
- `src/widgets/duo-list/ui/DuoPostDetailModal.tsx` — 모달 제목(듀오 상세), 삭제 확인, 조회 실패 문구 3건 정리

## Test plan
- [x] `pnpm lint` 통과 — 에러 0 (경고 5건은 이번 변경과 무관한 기존 unused import)
- [x] `npx tsc --noEmit` 통과
- [ ] 듀오 페이지 탭 라벨 확인 — 비로그인 시 「듀오 목록」만, 로그인 시 3개 모두 노출
- [ ] 「내 등록」 탭 빈 상태 문구 확인
- [ ] 듀오 카드 → 상세 모달 제목 및 삭제 확인 문구 확인

동작 변경 없이 사용자 노출 문자열만 수정.

Closes MP-XXX

🤖 Generated by Padosol
