### PR TITLE
feat: MP-106 게임 정적 데이터를 패치·언어별 CDN 경로에서 로드

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ API_URL_INTERNAL=http://localhost:8100/api
 # 정적 이미지 호스트
 NEXT_PUBLIC_IMAGE_HOST=https://static.mmrtr.shop
 
+# 게임 정적 데이터(챔피언/스펠/아이템/룬 JSON) 호스트
+# 실제 요청 경로: {호스트}/data/{패치버전}/{ddragon 로케일}/{파일}.json
+NEXT_PUBLIC_GAME_DATA_HOST=https://static.metapick.me
+
 # 로케일 리다이렉트를 301(영구)로 승격 (서버 전용)
 # next-intl 기본값은 307(임시). SEO 상 링크 에쿼티를 넘기려면 301 이어야 하지만,
 # 301 은 브라우저가 영구 캐시하므로 경로 규칙이 확정된 프로덕션에서만 true 로 켠다.

--- a/src/app/(main)/[locale]/GameDataLoader.tsx
+++ b/src/app/(main)/[locale]/GameDataLoader.tsx
@@ -1,23 +1,49 @@
 "use client";
 
 import { useEffect } from "react";
+import { useLocale } from "next-intl";
 import { useGameDataStore } from "@/shared/model/game-data";
 import { useSeasonStore } from "@/entities/season";
+import { toLocale } from "@/shared/i18n/locale";
 
 export default function GameDataLoader() {
+  const locale = toLocale(useLocale());
   const loadChampionData = useGameDataStore((s) => s.loadChampionData);
   const loadSummonerData = useGameDataStore((s) => s.loadSummonerData);
   const loadItemData = useGameDataStore((s) => s.loadItemData);
   const loadRuneData = useGameDataStore((s) => s.loadRuneData);
+  const setGameDataContext = useGameDataStore((s) => s.setGameDataContext);
   const loadSeasons = useSeasonStore((s) => s.loadSeasons);
 
   useEffect(() => {
-    loadChampionData();
-    loadSummonerData();
-    loadItemData();
-    loadRuneData();
-    loadSeasons();
-  }, [loadChampionData, loadSummonerData, loadItemData, loadRuneData, loadSeasons]);
+    let cancelled = false;
+
+    (async () => {
+      // 게임 데이터 경로에 패치 버전이 들어가므로 시즌 정보를 먼저 받는다.
+      // 실패하면 patchVersion 이 null 로 남아 번들된 public/data 로 떨어진다.
+      await loadSeasons();
+      if (cancelled) return;
+
+      setGameDataContext(useSeasonStore.getState().getLatestPatchVersion(), locale);
+
+      loadChampionData();
+      loadSummonerData();
+      loadItemData();
+      loadRuneData();
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    locale,
+    loadSeasons,
+    setGameDataContext,
+    loadChampionData,
+    loadSummonerData,
+    loadItemData,
+    loadRuneData,
+  ]);
 
   return null;
 }

--- a/src/entities/season/index.ts
+++ b/src/entities/season/index.ts
@@ -1,3 +1,4 @@
 export { getSeasons, getSeasonById } from "./api/seasonApi";
 export { useSeasonStore } from "./model/useSeasonStore";
+export { comparePatchVersion, pickLatestPatchVersion } from "./lib/patchVersion";
 export type { Season } from "./types";

--- a/src/entities/season/lib/patchVersion.ts
+++ b/src/entities/season/lib/patchVersion.ts
@@ -1,0 +1,32 @@
+/**
+ * 패치 버전 문자열("16.9", "16.14")을 숫자 세그먼트 단위로 비교한다.
+ * 사전순 비교면 "16.9" > "16.14" 가 되어버리므로 직접 나눠서 본다.
+ */
+export function comparePatchVersion(a: string, b: string): number {
+  const left = a.split(".").map(Number);
+  const right = b.split(".").map(Number);
+  const length = Math.max(left.length, right.length);
+
+  for (let i = 0; i < length; i++) {
+    const l = left[i] ?? 0;
+    const r = right[i] ?? 0;
+    if (Number.isNaN(l) || Number.isNaN(r)) {
+      // 숫자로 파싱되지 않는 버전은 사전순으로 떨어뜨린다
+      return a.localeCompare(b);
+    }
+    if (l !== r) return l - r;
+  }
+
+  return 0;
+}
+
+/** 정렬 순서를 신뢰하지 않고 목록에서 최신 패치를 고른다. */
+export function pickLatestPatchVersion(
+  patchVersions: readonly string[] | undefined
+): string | null {
+  if (!patchVersions || patchVersions.length === 0) return null;
+
+  return patchVersions.reduce((latest, current) =>
+    comparePatchVersion(current, latest) > 0 ? current : latest
+  );
+}

--- a/src/entities/season/model/useSeasonStore.ts
+++ b/src/entities/season/model/useSeasonStore.ts
@@ -1,4 +1,5 @@
 import { getSeasons } from "../api/seasonApi";
+import { pickLatestPatchVersion } from "../lib/patchVersion";
 import type { Season } from "../types";
 import { create } from "zustand";
 
@@ -9,6 +10,7 @@ interface SeasonState {
   loadSeasons: () => Promise<void>;
   getLatestSeason: () => Season | null;
   getLatestSeasonValue: () => string | undefined;
+  getLatestPatchVersion: () => string | null;
 }
 
 export const useSeasonStore = create<SeasonState>((set, get) => ({
@@ -27,6 +29,12 @@ export const useSeasonStore = create<SeasonState>((set, get) => ({
   getLatestSeasonValue: () => {
     const latest = get().getLatestSeason();
     return latest ? String(latest.seasonValue) : undefined;
+  },
+
+  /** 최신 시즌의 패치 목록에서 가장 높은 버전. 게임 정적 데이터 경로에 쓰인다. */
+  getLatestPatchVersion: () => {
+    const latest = get().getLatestSeason();
+    return pickLatestPatchVersion(latest?.patchVersions);
   },
 
   loadSeasons: async () => {

--- a/src/shared/config/game-data.ts
+++ b/src/shared/config/game-data.ts
@@ -1,0 +1,42 @@
+import { DDRAGON_LOCALE, type Locale } from "@/shared/i18n/locale";
+
+/**
+ * 게임 정적 데이터(Data Dragon 파생 JSON) 호스트.
+ * 이미지 호스트(IMAGE_HOST)와 물리적으로 같은 CDN 이지만, 이미지는 배포마다 바뀌지 않고
+ * 데이터는 패치/언어별로 갈라지므로 오버라이드 지점을 분리해 둔다.
+ */
+export const GAME_DATA_HOST =
+  process.env.NEXT_PUBLIC_GAME_DATA_HOST || "https://static.metapick.me";
+
+export const GAME_DATA_FILES = {
+  champion: "championFull.json",
+  summoner: "summoner.json",
+  item: "item.json",
+  rune: "runesReforged.json",
+} as const;
+
+export type GameDataFile = (typeof GAME_DATA_FILES)[keyof typeof GAME_DATA_FILES];
+
+/**
+ * 패치 버전을 아직 모를 때 쓰는 번들 폴백 경로 (`public/data/*.json`).
+ * 시즌 API 가 늦거나 실패해도 툴팁/스펠 이름이 빈 채로 남지 않게 한다.
+ */
+export function localGameDataUrl(file: GameDataFile): string {
+  return `/data/${file}`;
+}
+
+/**
+ * `https://static.metapick.me/data/{패치버전}/{ddragon 로케일}/{파일}`
+ * 패치 버전이 없으면 번들 폴백 경로로 떨어진다.
+ */
+export function gameDataUrl(
+  file: GameDataFile,
+  patchVersion: string | null | undefined,
+  locale: Locale
+): string {
+  if (!patchVersion) {
+    return localGameDataUrl(file);
+  }
+
+  return `${GAME_DATA_HOST}/data/${patchVersion}/${DDRAGON_LOCALE[locale]}/${file}`;
+}

--- a/src/shared/i18n/locale.ts
+++ b/src/shared/i18n/locale.ts
@@ -20,8 +20,8 @@ export const INTL_LOCALE: Record<Locale, string> = {
 
 /**
  * Data Dragon 로케일.
- * 1차에서는 사용처가 없다 — 게임 데이터는 한국어 고정으로 유지(MP-106).
- * 다국어 게임 데이터 API를 붙일 때 쓸 매핑을 미리 자리만 잡아둔다.
+ * 게임 정적 데이터 경로(`/data/{패치}/{여기}/…`)의 디렉토리 이름으로 쓰인다.
+ * @see shared/config/game-data.ts
  */
 export const DDRAGON_LOCALE: Record<Locale, string> = {
   ko: "ko_KR",

--- a/src/shared/model/game-data/useGameDataStore.ts
+++ b/src/shared/model/game-data/useGameDataStore.ts
@@ -1,4 +1,11 @@
 import { create } from "zustand";
+import {
+  GAME_DATA_FILES,
+  gameDataUrl,
+  localGameDataUrl,
+  type GameDataFile,
+} from "@/shared/config/game-data";
+import { DEFAULT_LOCALE, type Locale } from "@/shared/i18n/locale";
 import type {
   ChampionJson,
   SummonerSpellData,
@@ -10,6 +17,9 @@ import type {
 } from "./types";
 
 interface GameDataState {
+  /** 현재 데이터를 받아오는 기준 패치. null 이면 번들된 `public/data` 를 쓴다. */
+  patchVersion: string | null;
+  locale: Locale;
   championData: ChampionJson | null;
   summonerData: SummonerJson | null;
   itemData: ItemJson | null;
@@ -22,6 +32,12 @@ interface GameDataState {
   summonerLoadPromise: Promise<void> | null;
   itemLoadPromise: Promise<void> | null;
   runeLoadPromise: Promise<void> | null;
+  /** 각 데이터가 어떤 (패치, 언어) 조합으로 채워졌는지 — 컨텍스트가 바뀌면 다시 받는다. */
+  championLoadedKey: string | null;
+  summonerLoadedKey: string | null;
+  itemLoadedKey: string | null;
+  runeLoadedKey: string | null;
+  setGameDataContext: (patchVersion: string | null, locale: Locale) => void;
   loadChampionData: () => Promise<void>;
   loadSummonerData: () => Promise<void>;
   loadItemData: () => Promise<void>;
@@ -31,7 +47,106 @@ interface GameDataState {
   getRuneTreeById: (id: number) => RuneReforgedTree | undefined;
 }
 
+function contextKey(patchVersion: string | null, locale: Locale): string {
+  return `${patchVersion ?? "bundled"}|${locale}`;
+}
+
+/**
+ * CDN(`static.metapick.me/data/{패치}/{로케일}/…`)에서 받아오고,
+ * 해당 패치/언어 파일이 아직 없으면 번들된 `public/data` 로 떨어진다.
+ */
+async function fetchGameData<T>(
+  file: GameDataFile,
+  patchVersion: string | null,
+  locale: Locale
+): Promise<T> {
+  const url = gameDataUrl(file, patchVersion, locale);
+
+  try {
+    return await fetchJson<T>(url);
+  } catch (error) {
+    const fallbackUrl = localGameDataUrl(file);
+    if (url === fallbackUrl) throw error;
+
+    console.warn(`Failed to load ${url}, falling back to ${fallbackUrl}:`, error);
+    return fetchJson<T>(fallbackUrl);
+  }
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as T;
+}
+
+type LoaderFields = {
+  data: "championData" | "summonerData" | "itemData" | "runeData";
+  loading: "isLoadingChampion" | "isLoadingSummoner" | "isLoadingItem" | "isLoadingRune";
+  promise:
+    | "championLoadPromise"
+    | "summonerLoadPromise"
+    | "itemLoadPromise"
+    | "runeLoadPromise";
+  loadedKey:
+    | "championLoadedKey"
+    | "summonerLoadedKey"
+    | "itemLoadedKey"
+    | "runeLoadedKey";
+  file: GameDataFile;
+  label: string;
+};
+
+type SetState = (partial: Partial<GameDataState>) => void;
+type GetState = () => GameDataState;
+
+function createLoader<T>(set: SetState, get: GetState, fields: LoaderFields) {
+  return async (): Promise<void> => {
+    const state = get();
+    const key = contextKey(state.patchVersion, state.locale);
+
+    if (state[fields.loadedKey] === key) {
+      return;
+    }
+
+    const inflight = state[fields.promise];
+    if (inflight) {
+      return inflight;
+    }
+
+    const loadPromise = (async () => {
+      set({ [fields.loading]: true } as Partial<GameDataState>);
+      try {
+        const data = await fetchGameData<T>(fields.file, state.patchVersion, state.locale);
+
+        // 로딩 중 언어/패치가 바뀌었다면 늦게 도착한 응답이므로 버린다
+        const current = get();
+        if (contextKey(current.patchVersion, current.locale) !== key) {
+          set({ [fields.loading]: false, [fields.promise]: null } as Partial<GameDataState>);
+          return;
+        }
+
+        set({
+          [fields.data]: data,
+          [fields.loadedKey]: key,
+          [fields.loading]: false,
+          [fields.promise]: null,
+        } as Partial<GameDataState>);
+      } catch (error) {
+        console.error(`Failed to load ${fields.label} data:`, error);
+        set({ [fields.loading]: false, [fields.promise]: null } as Partial<GameDataState>);
+      }
+    })();
+
+    set({ [fields.promise]: loadPromise } as Partial<GameDataState>);
+    return loadPromise;
+  };
+}
+
 export const useGameDataStore = create<GameDataState>((set, get) => ({
+  patchVersion: null,
+  locale: DEFAULT_LOCALE,
   championData: null,
   summonerData: null,
   itemData: null,
@@ -44,113 +159,67 @@ export const useGameDataStore = create<GameDataState>((set, get) => ({
   summonerLoadPromise: null,
   itemLoadPromise: null,
   runeLoadPromise: null,
+  championLoadedKey: null,
+  summonerLoadedKey: null,
+  itemLoadedKey: null,
+  runeLoadedKey: null,
 
-  loadChampionData: async () => {
+  /**
+   * 패치/언어를 바꾼다. 이미 받아둔 데이터는 새 데이터가 도착할 때까지 그대로 두어
+   * 언어 전환 순간에 툴팁·스펠 이름이 빈 칸으로 깜빡이지 않게 한다.
+   */
+  setGameDataContext: (patchVersion, locale) => {
     const state = get();
-
-    if (state.championData) {
+    if (state.patchVersion === patchVersion && state.locale === locale) {
       return;
     }
 
-    if (state.championLoadPromise) {
-      return state.championLoadPromise;
-    }
-
-    const loadPromise = (async () => {
-      set({ isLoadingChampion: true });
-      try {
-        const response = await fetch("/data/championFull.json");
-        const data = (await response.json()) as ChampionJson;
-        set({ championData: data, isLoadingChampion: false, championLoadPromise: null });
-      } catch (error) {
-        console.error("Failed to load champion data:", error);
-        set({ isLoadingChampion: false, championLoadPromise: null });
-      }
-    })();
-
-    set({ championLoadPromise: loadPromise });
-    return loadPromise;
+    set({
+      patchVersion,
+      locale,
+      // 진행 중이던 요청은 이전 컨텍스트의 것 — 새 요청을 막지 않도록 놓아준다
+      championLoadPromise: null,
+      summonerLoadPromise: null,
+      itemLoadPromise: null,
+      runeLoadPromise: null,
+    });
   },
 
-  loadSummonerData: async () => {
-    const state = get();
+  loadChampionData: createLoader<ChampionJson>(set, get, {
+    data: "championData",
+    loading: "isLoadingChampion",
+    promise: "championLoadPromise",
+    loadedKey: "championLoadedKey",
+    file: GAME_DATA_FILES.champion,
+    label: "champion",
+  }),
 
-    if (state.summonerData) {
-      return;
-    }
+  loadSummonerData: createLoader<SummonerJson>(set, get, {
+    data: "summonerData",
+    loading: "isLoadingSummoner",
+    promise: "summonerLoadPromise",
+    loadedKey: "summonerLoadedKey",
+    file: GAME_DATA_FILES.summoner,
+    label: "summoner",
+  }),
 
-    if (state.summonerLoadPromise) {
-      return state.summonerLoadPromise;
-    }
+  loadItemData: createLoader<ItemJson>(set, get, {
+    data: "itemData",
+    loading: "isLoadingItem",
+    promise: "itemLoadPromise",
+    loadedKey: "itemLoadedKey",
+    file: GAME_DATA_FILES.item,
+    label: "item",
+  }),
 
-    const loadPromise = (async () => {
-      set({ isLoadingSummoner: true });
-      try {
-        const response = await fetch("/data/summoner.json");
-        const data = (await response.json()) as SummonerJson;
-        set({ summonerData: data, isLoadingSummoner: false, summonerLoadPromise: null });
-      } catch (error) {
-        console.error("Failed to load summoner data:", error);
-        set({ isLoadingSummoner: false, summonerLoadPromise: null });
-      }
-    })();
-
-    set({ summonerLoadPromise: loadPromise });
-    return loadPromise;
-  },
-  loadItemData: async () => {
-    const state = get();
-
-    if (state.itemData) {
-      return;
-    }
-
-    if (state.itemLoadPromise) {
-      return state.itemLoadPromise;
-    }
-
-    const loadPromise = (async () => {
-      set({ isLoadingItem: true });
-      try {
-        const response = await fetch("/data/item.json");
-        const data = (await response.json()) as ItemJson;
-        set({ itemData: data, isLoadingItem: false, itemLoadPromise: null });
-      } catch (error) {
-        console.error("Failed to load item data:", error);
-        set({ isLoadingItem: false, itemLoadPromise: null });
-      }
-    })();
-
-    set({ itemLoadPromise: loadPromise });
-    return loadPromise;
-  },
-
-  loadRuneData: async () => {
-    const state = get();
-
-    if (state.runeData) {
-      return;
-    }
-
-    if (state.runeLoadPromise) {
-      return state.runeLoadPromise;
-    }
-
-    const loadPromise = (async () => {
-      set({ isLoadingRune: true });
-      try {
-        const response = await fetch("/data/runesReforged.json");
-        const data = (await response.json()) as RuneReforgedData;
-        set({ runeData: data, isLoadingRune: false, runeLoadPromise: null });
-      } catch (error) {
-        console.error("Failed to load rune data:", error);
-        set({ isLoadingRune: false, runeLoadPromise: null });
-      }
-    })();
-
-    set({ runeLoadPromise: loadPromise });
-    return loadPromise;
-  },
+  loadRuneData: createLoader<RuneReforgedData>(set, get, {
+    data: "runeData",
+    loading: "isLoadingRune",
+    promise: "runeLoadPromise",
+    loadedKey: "runeLoadedKey",
+    file: GAME_DATA_FILES.rune,
+    label: "rune",
+  }),
 
   getSpellByNumericId: (id: number) => {
     const { summonerData } = get();

--- a/tests/game-data.spec.ts
+++ b/tests/game-data.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * MP-108 게임 정적 데이터 로딩 회귀 테스트.
+ *
+ * 챔피언/스펠/아이템/룬 JSON 은 `static.metapick.me/data/{패치}/{로케일}/…` 에서 받아온다.
+ * 실제 CDN 에 붙으면 패치가 올라갈 때마다 테스트가 흔들리므로 여기서는 응답을 가로채고
+ * "어떤 URL 로 요청했는가" 만 본다.
+ */
+
+const CDN_PATTERN = "https://static.metapick.me/data/**";
+const DATA_FILE_RE = /\/(summoner|championFull|item|runesReforged)\.json$/;
+
+/** 최신 패치가 목록 첫 번째도, 사전순 최대(16.9)도 아닌 배치 — 숫자 비교로 16.14 가 나와야 한다. */
+const SEASONS_RESPONSE = {
+  result: "SUCCESS",
+  data: [
+    { seasonValue: 15, seasonName: "15 시즌", patchVersions: ["15.20", "15.24"] },
+    { seasonValue: 16, seasonName: "16 시즌", patchVersions: ["16.14", "16.9", "16.13"] },
+  ],
+  errorMessage: null,
+};
+
+const EXPECTED_LATEST_PATCH = "16.14";
+
+async function stubGameData(page: Page): Promise<string[]> {
+  const requestedUrls: string[] = [];
+
+  await page.route("**/v1/seasons", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(SEASONS_RESPONSE),
+    })
+  );
+
+  await page.route(CDN_PATTERN, (route) => {
+    const url = route.request().url();
+    const body = url.endsWith("runesReforged.json")
+      ? JSON.stringify([])
+      : JSON.stringify({ data: {} });
+    return route.fulfill({ status: 200, contentType: "application/json", body });
+  });
+
+  page.on("request", (request) => {
+    if (DATA_FILE_RE.test(new URL(request.url()).pathname)) {
+      requestedUrls.push(request.url());
+    }
+  });
+
+  return requestedUrls;
+}
+
+function dataUrlsFor(urls: string[], locale: string): string[] {
+  return urls.filter((url) => url.includes(`/${EXPECTED_LATEST_PATCH}/${locale}/`));
+}
+
+test.describe("게임 정적 데이터", () => {
+  test("최신 패치와 현재 언어 경로로 요청한다", async ({ page }) => {
+    const urls = await stubGameData(page);
+
+    await page.goto("/ko");
+    await expect
+      .poll(() => dataUrlsFor(urls, "ko_KR").length, { timeout: 15_000 })
+      .toBeGreaterThanOrEqual(4);
+
+    const koUrls = dataUrlsFor(urls, "ko_KR");
+    for (const file of ["championFull", "summoner", "item", "runesReforged"]) {
+      expect(
+        koUrls.some((url) => url.endsWith(`/${file}.json`)),
+        `${file}.json 요청이 있어야 한다`
+      ).toBe(true);
+    }
+    // 패치 목록 순서·사전순이 아니라 숫자 비교로 최신을 골랐는지
+    expect(koUrls.every((url) => url.includes(`/data/${EXPECTED_LATEST_PATCH}/`))).toBe(true);
+  });
+
+  test("영어 페이지는 en_US 데이터를 받는다", async ({ page }) => {
+    const urls = await stubGameData(page);
+
+    await page.goto("/en");
+    await expect
+      .poll(() => dataUrlsFor(urls, "en_US").length, { timeout: 15_000 })
+      .toBeGreaterThanOrEqual(4);
+
+    expect(dataUrlsFor(urls, "ko_KR")).toHaveLength(0);
+  });
+
+  test("언어 스위처로 바꾸면 해당 언어 데이터를 다시 받는다", async ({ page }) => {
+    const urls = await stubGameData(page);
+
+    await page.goto("/ko");
+    await expect
+      .poll(() => dataUrlsFor(urls, "ko_KR").length, { timeout: 15_000 })
+      .toBeGreaterThanOrEqual(4);
+
+    await page.getByRole("button", { name: /언어|language/i }).first().click();
+    await page.getByRole("option", { name: "English" }).click();
+
+    await expect(page).toHaveURL(/\/en(\/|$)/);
+    await expect
+      .poll(() => dataUrlsFor(urls, "en_US").length, { timeout: 15_000 })
+      .toBeGreaterThanOrEqual(4);
+  });
+
+  test("시즌 정보를 받지 못하면 번들된 데이터로 떨어진다", async ({ page }) => {
+    const requestedPaths: string[] = [];
+
+    await page.route("**/v1/seasons", (route) => route.abort());
+    page.on("request", (request) => {
+      const { pathname } = new URL(request.url());
+      if (DATA_FILE_RE.test(pathname)) requestedPaths.push(pathname);
+    });
+
+    await page.goto("/ko");
+    await expect
+      .poll(() => requestedPaths.length, { timeout: 15_000 })
+      .toBeGreaterThanOrEqual(4);
+
+    // 패치를 모르면 CDN 대신 public/data 를 쓴다
+    expect(requestedPaths.every((path) => path.startsWith("/data/"))).toBe(true);
+  });
+});

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -3,8 +3,8 @@ import { test, expect } from "@playwright/test";
 /**
  * MP-107 로케일 라우팅/번역 회귀 테스트.
  *
- * 게임 데이터(챔피언·아이템·룬 이름)는 아직 한국어 고정이므로(MP-106)
  * 여기서는 UI 크롬(내비게이션·섹션 제목·언어 스위처)만 검증한다.
+ * 게임 데이터(챔피언·아이템·룬 이름)의 언어별 로딩은 game-data.spec.ts 담당(MP-108).
  */
 
 const KO_HOME_HEADING = "이번 주 무료 챔피언";


### PR DESCRIPTION
## 요약
- 챔피언·스펠·아이템·룬 JSON 을 번들된 `public/data` 고정 파일 대신 `static.metapick.me/data/{최신패치}/{ddragon 로케일}/` 에서 받아온다.
- 패치는 시즌 API 응답에서 숫자 비교로 최신을 고르고, 언어를 바꾸면 해당 언어 데이터를 다시 받는다.
- CDN 에 아직 파일이 없어(전 경로 403) 패치를 모르거나 응답이 없으면 기존 `public/data` 로 떨어진다 — 업로드 전까지 현재 동작이 그대로 유지된다.

## 변경 내용
- `src/shared/config/game-data.ts` — 게임 데이터 호스트·파일 목록과 URL 조립. `NEXT_PUBLIC_GAME_DATA_HOST` 로 오버라이드, 패치가 없으면 번들 경로 반환
- `src/shared/model/game-data/useGameDataStore.ts` — `(패치, 언어)` 컨텍스트 도입. 조합이 바뀌면 재로딩하고, 전환 중 늦게 도착한 이전 언어 응답은 버린다. 새 데이터가 올 때까지 기존 데이터를 유지해 툴팁이 빈 칸으로 깜빡이지 않는다
- `src/entities/season/lib/patchVersion.ts` — 패치 버전 숫자 세그먼트 비교. 사전순이면 `16.9 > 16.14` 가 되어버려 직접 나눠서 본다
- `src/entities/season/model/useSeasonStore.ts` — `getLatestPatchVersion()` 추가 (목록 정렬 순서를 신뢰하지 않음)
- `src/app/(main)/[locale]/GameDataLoader.tsx` — 시즌을 먼저 받아 패치를 확정한 뒤 게임 데이터를 로드. `useLocale()` 변경 시 재실행
- `src/shared/i18n/locale.ts` — `DDRAGON_LOCALE` 이 실제 경로에 쓰이게 되어 주석 갱신
- `tests/game-data.spec.ts` — CDN·시즌 API 응답을 가로채 요청 URL 만 검증하는 회귀 테스트 4종
- `.env.example` — `NEXT_PUBLIC_GAME_DATA_HOST` 추가

## 확인
- [x] `npx tsc --noEmit` exit 0
- [x] `pnpm lint` error 0 (기존 warning 4건만 잔존, 이번 변경과 무관)
- [x] `npx next build` 성공
- [x] E2E `tests/game-data.spec.ts` 4/4 통과 — 최신 패치 선택(`16.14`), `/ko`→`ko_KR`, `/en`→`en_US`, 언어 스위처 전환 시 재요청, 시즌 API 실패 시 `public/data` 폴백
- [x] E2E `tests/i18n.spec.ts` 13/13 통과 (회귀 없음)
- [ ] CDN 에 `data/{패치}/{로케일}/*.json` 업로드 — 현재 전 경로 403, 업로드 전까지 폴백으로 동작
- [ ] `static.metapick.me` 의 CORS 헤더 확인 — 이미지는 `<img>` 라 무관하지만 데이터는 `fetch` 라 필요
- [ ] 언어 디렉토리 규칙이 `ko_KR`/`en_US` 가 맞는지 확인 (다르면 `src/shared/i18n/locale.ts` 의 `DDRAGON_LOCALE` 만 수정)

### 참고
- 챔피언은 `championFull.json` 을 유지했다. 툴팁이 스킬·패시브 데이터를 쓰는데 축약본 `champion.json` 에는 없다.
- 룬(`runesReforged.json`)도 같은 경로 규칙에 포함시켰다. 이슈에는 챔피언·아이템·룬·스펠이 모두 있고 룬 이름·설명도 언어별이며, 폴백이 있어 CDN 에 없으면 기존대로 동작한다.
- `champion-stats` 필터가 `patchVersions[0]` 을 최신으로 쓰는 기존 코드는 이번 범위 밖이라 건드리지 않았다. API 가 오름차순이라 가장 오래된 패치를 고르고 있을 수 있어 별도 확인이 필요하다.

Closes MP-106

🤖 Generated by Padosol
